### PR TITLE
slack redirect url cleanup:

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -39,8 +39,8 @@ class ApplicationController @Inject() (
     val maybeResult = for {
       scopes <- configuration.getString("silhouette.slack.scope")
       clientId <- configuration.getString("silhouette.slack.clientID")
-      redirectUrl <- configuration.getString("silhouette.slack.redirectURL").map(UriEncoding.encodePathSegment(_, "utf-8"))
     } yield {
+        val redirectUrl = routes.SocialAuthController.installForSlack().absoluteURL(secure=true)
         Ok(views.html.addToSlack(request.identity, scopes, clientId, redirectUrl))
       }
     maybeResult.getOrElse(Redirect(routes.ApplicationController.index))

--- a/conf/silhouette.conf
+++ b/conf/silhouette.conf
@@ -30,8 +30,7 @@ silhouette {
     clientID=${?SLACK_CLIENT_ID}
     clientSecret="changeme"
     clientSecret=${?SLACK_CLIENT_SECRET}
-    redirectURL="https://ellipsis.ai/authenticate/slack"
-    redirectURL=${?SLACK_REDIRECT_URL}
+    redirectURL="/authenticate/slack"
     scope="chat:write:bot channels:read groups:read team:read commands bot"
     signInScope="identity.basic"
   }


### PR DESCRIPTION
- use relative path in config (which is still required by silhouette)
- no longer need the env var
- use route for install redirect url
