### PR TITLE
Listen to changes to slackbot_profiles table and add/remove RTM clients as necessary

### DIFF
--- a/app/actors/SlackBotProfileChangeListenerActor.scala
+++ b/app/actors/SlackBotProfileChangeListenerActor.scala
@@ -1,0 +1,69 @@
+package actors
+
+import javax.inject.Inject
+
+import akka.actor.Actor
+import models.accounts.SlackBotProfile
+import org.postgresql.{PGConnection, PGNotification}
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import services.SlackService
+import slick.driver.PostgresDriver.api._
+
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+object SlackBotProfileChangeListenerActor {
+  final val name = "slackbot-profile-change-listener"
+}
+
+class SlackBotProfileChangeListenerActor @Inject() (val slackService: SlackService) extends Actor {
+
+  val models = slackService.models
+
+  implicit val slackBotProfileReads: Reads[SlackBotProfile] = (
+    (JsPath \ "user_id").read[String] and
+      (JsPath \ "team_id").read[String] and
+      (JsPath \ "slack_team_id").read[String] and
+      (JsPath \ "token").read[String]
+    )(SlackBotProfile.apply _)
+
+  val tick = context.system.scheduler.schedule(500 millis, 1000 millis, self, "tick")
+
+  override def preStart() = {
+    models.runNow(sqlu"LISTEN events")
+  }
+
+  override def postStop() = {
+    tick.cancel()
+  }
+
+  def receive = {
+    case "tick" => {
+      val action = SimpleDBIO[Boolean] { context =>
+        val pgConnection = context.connection.unwrap[PGConnection](classOf[PGConnection])
+        val notifications = Option(pgConnection.getNotifications).getOrElse(Array[PGNotification]())
+
+        notifications.foreach { ea =>
+          val json = Json.parse(ea.getParameter)
+          val action = (json \ "action").as[String]
+          val profileJson = json \ "data"
+          profileJson.validate[SlackBotProfile] match {
+            case JsSuccess(profile, jsPath) => {
+              action match {
+                case "INSERT" | "UPDATE" => slackService.startFor(profile)
+                case "DELETE" => slackService.stopFor(profile)
+              }
+            }
+            case JsError(err) => println("oops")
+          }
+        }
+
+        true
+      }
+
+      models.runNow(action)
+    }
+  }
+}

--- a/app/modules/ActorModule.scala
+++ b/app/modules/ActorModule.scala
@@ -1,0 +1,12 @@
+package modules
+
+import com.google.inject.AbstractModule
+import play.api.libs.concurrent.AkkaGuiceSupport
+
+import actors.SlackBotProfileChangeListenerActor
+
+class ActorModule extends AbstractModule with AkkaGuiceSupport {
+  def configure = {
+    bindActor[SlackBotProfileChangeListenerActor](SlackBotProfileChangeListenerActor.name)
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -65,5 +65,4 @@ application.shouldSendErrorEmails=false
 application.apiBaseUrl = ${API_BASE_URL}
 
 include "aws.conf"
-
-play.modules.enabled += "modules.ServiceModule"
+include "modules.conf"

--- a/conf/docker.conf
+++ b/conf/docker.conf
@@ -35,5 +35,4 @@ application.shouldSendErrorEmails=${?SHOULD_SEND_ERROR_EMAILS}
 
 include "auth.conf"
 include "aws.conf"
-
-play.modules.enabled += "modules.ServiceModule"
+include "modules.conf"

--- a/conf/evolutions/default/4.sql
+++ b/conf/evolutions/default/4.sql
@@ -1,0 +1,43 @@
+# --- !Ups
+
+CREATE OR REPLACE FUNCTION notify_event() RETURNS TRIGGER AS $$
+
+    DECLARE
+        data json;;
+        notification json;;
+
+    BEGIN
+
+        -- Convert the old or new row to JSON, based on the kind of action.
+        -- Action = DELETE?             -> OLD row
+        -- Action = INSERT or UPDATE?   -> NEW row
+        IF (TG_OP = 'DELETE') THEN
+            data = row_to_json(OLD);;
+        ELSE
+            data = row_to_json(NEW);;
+        END IF;;
+
+        -- Contruct the notification as a JSON string.
+        notification = json_build_object(
+                          'table',TG_TABLE_NAME,
+                          'action', TG_OP,
+                          'data', data);;
+
+
+        -- Execute pg_notify(channel, notification)
+        PERFORM pg_notify('events',notification::text);;
+
+        -- Result is ignored since this is an AFTER trigger
+        RETURN NULL;;
+    END;;
+
+$$ LANGUAGE plpgsql;;
+
+CREATE TRIGGER slack_bot_profiles_notify_event
+AFTER INSERT OR UPDATE OR DELETE ON slack_bot_profiles
+    FOR EACH ROW EXECUTE PROCEDURE notify_event();
+
+# --- !Downs
+
+DROP TRIGGER IF EXISTS slack_bot_profiles_notify_event;
+DROP FUNCTION IF EXISTS notify_event();

--- a/conf/modules.conf
+++ b/conf/modules.conf
@@ -1,0 +1,2 @@
+play.modules.enabled += "modules.ServiceModule"
+play.modules.enabled += "modules.ActorModule"


### PR DESCRIPTION
- means you don't need a system restart after "Add to slack" anymore
