### PR TITLE
Use compatible CommonJS "require" format instead of RequireJS

### DIFF
--- a/app/assets/javascripts/behavior_editor.jsx
+++ b/app/assets/javascripts/behavior_editor.jsx
@@ -1,30 +1,16 @@
-define('behavior_editor', [
-  'react',
-  'react-dom',
-  './react-codemirror',
-  './codemirror/mode/javascript/javascript',
-  './behavior_editor_mixin',
-  './behavior_editor_delete_button',
-  './behavior_editor_hidden_json_input',
-  './behavior_editor_input',
-  './behavior_editor_settings_button',
-  './behavior_editor_settings_menu',
-  './behavior_editor_trigger_input',
-  './behavior_editor_user_input_definition'
-], function(
-  React,
-  ReactDOM,
-  Codemirror,
-  CodemirrorJSMode,
-  BehaviorEditorMixin,
-  BehaviorEditorDeleteButton,
-  BehaviorEditorHiddenJsonInput,
-  BehaviorEditorInput,
-  BehaviorEditorSettingsButton,
-  BehaviorEditorSettingsMenu,
-  BehaviorEditorTriggerInput,
-  BehaviorEditorUserInputDefinition
-) {
+define(function(require) {
+var React = require('react'),
+  ReactDOM = require('react-dom'),
+  Codemirror = require('./react-codemirror'),
+  CodemirrorJSMode = require('./codemirror/mode/javascript/javascript'),
+  BehaviorEditorMixin = require('./behavior_editor_mixin'),
+  BehaviorEditorDeleteButton = require('./behavior_editor_delete_button'),
+  BehaviorEditorHiddenJsonInput = require('./behavior_editor_hidden_json_input'),
+  BehaviorEditorInput = require('./behavior_editor_input'),
+  BehaviorEditorSettingsButton = require('./behavior_editor_settings_button'),
+  BehaviorEditorSettingsMenu = require('./behavior_editor_settings_menu'),
+  BehaviorEditorTriggerInput = require('./behavior_editor_trigger_input'),
+  BehaviorEditorUserInputDefinition = require('./behavior_editor_user_input_definition');
 
 var BehaviorEditor = React.createClass({
   displayName: 'BehaviorEditor',

--- a/app/assets/javascripts/behavior_editor_delete_button.jsx
+++ b/app/assets/javascripts/behavior_editor_delete_button.jsx
@@ -1,10 +1,6 @@
-define([
-  'react',
-  './behavior_editor_mixin'
-], function(
-  React,
-  BehaviorEditorMixin
-) {
+define(function(require) {
+var React = require('react'),
+  BehaviorEditorMixin = require('./behavior_editor_mixin');
 
 return React.createClass({
   displayName: 'BehaviorEditorDeleteButton',

--- a/app/assets/javascripts/behavior_editor_hidden_json_input.jsx
+++ b/app/assets/javascripts/behavior_editor_hidden_json_input.jsx
@@ -1,8 +1,5 @@
-define([
-  'react'
-], function(
-  React
-) {
+define(function(require) {
+var React = require('react');
 
 return React.createClass({
   displayName: 'BehaviorEditorHiddenJsonInput',

--- a/app/assets/javascripts/behavior_editor_input.jsx
+++ b/app/assets/javascripts/behavior_editor_input.jsx
@@ -1,8 +1,5 @@
-define([
-  'react'
-], function(
-  React
-) {
+define(function(require) {
+var React = require('react');
 
 return React.createClass({
   displayName: 'BehaviorEditorInput',

--- a/app/assets/javascripts/behavior_editor_settings_button.jsx
+++ b/app/assets/javascripts/behavior_editor_settings_button.jsx
@@ -1,8 +1,5 @@
-define([
-  'react'
-], function(
-  React
-) {
+define(function(require) {
+var React = require('react');
 
 return React.createClass({
   displayName: 'BehaviorEditorSettingsButton',

--- a/app/assets/javascripts/behavior_editor_settings_menu.jsx
+++ b/app/assets/javascripts/behavior_editor_settings_menu.jsx
@@ -1,10 +1,6 @@
-define([
-  'react',
-  './behavior_editor_mixin'
-], function(
-  React,
-  BehaviorEditorMixin
-) {
+define(function(require) {
+var React = require('react'),
+  BehaviorEditorMixin = require('./behavior_editor_mixin');
 
 return React.createClass({
   displayName: 'BehaviorEditorSettingsMenu',

--- a/app/assets/javascripts/behavior_editor_trigger_input.jsx
+++ b/app/assets/javascripts/behavior_editor_trigger_input.jsx
@@ -1,12 +1,7 @@
-define([
-  'react',
-  './behavior_editor_delete_button',
-  './behavior_editor_input'
-], function(
-  React,
-  BehaviorEditorDeleteButton,
-  BehaviorEditorInput
-) {
+define(function(require) {
+var React = require('react'),
+  BehaviorEditorDeleteButton = require('./behavior_editor_delete_button'),
+  BehaviorEditorInput = require('./behavior_editor_input');
 
 return React.createClass({
   displayName: 'BehaviorEditorTriggerInput',

--- a/app/assets/javascripts/behavior_editor_user_input_definition.jsx
+++ b/app/assets/javascripts/behavior_editor_user_input_definition.jsx
@@ -1,12 +1,7 @@
-define([
-  'react',
-  './behavior_editor_delete_button',
-  './behavior_editor_input'
-], function(
-  React,
-  BehaviorEditorDeleteButton,
-  BehaviorEditorInput
-) {
+define(function(require) {
+var React = require('react'),
+  BehaviorEditorDeleteButton = require('./behavior_editor_delete_button'),
+  BehaviorEditorInput = require('./behavior_editor_input');
 
 return React.createClass({
   displayName: 'BehaviorEditorUserInputDefinition',


### PR DESCRIPTION
Switch to RequireJS's CommonJS format of requiring dependencies because it's nicer to work with and seems to optimize just fine.

As long as the dependencies are all declared at the beginning, this still optimizes correctly in the production build.
