### PR TITLE
Use spaces instead of tabs on the editor

### DIFF
--- a/app/assets/javascripts/behavior_editor.jsx
+++ b/app/assets/javascripts/behavior_editor.jsx
@@ -310,10 +310,20 @@ var BehaviorEditor = React.createClass({
                   onChange={this.onCodeChange}
                   options={{
                     mode: "javascript",
+                    firstLineNumber: 2,
+                    indentUnit: 2,
+                    indentWithTabs: false,
                     lineWrapping: this.state.codeEditorUseLineWrapping,
                     lineNumbers: true,
-                    firstLineNumber: 2,
-                    viewportMargin: Infinity
+                    smartIndent: true,
+                    tabSize: 2,
+                    viewportMargin: Infinity,
+                    extraKeys: {
+                      Tab: function(cm) {
+                        var spaces = Array(cm.getOption("indentUnit") + 1).join(" ");
+                        cm.replaceSelection(spaces);
+                      }
+                    }
                   }}
                 />
                 <div className="position-absolute position-top-right">


### PR DESCRIPTION
- Modify the code editor to always use spaces instead of tabs
- Include all of the preferred options, even though some of them are the defaults
