### PR TITLE
Fix max-height bug on code editor

### DIFF
--- a/app/assets/stylesheets/main.less
+++ b/app/assets/stylesheets/main.less
@@ -1137,7 +1137,7 @@ button.button-dropdown-trigger {
 
 .display-visible {
   /* This works better if the element has an explicit max height set */
-  max-height: 1000px;
+  max-height: 10000px;
 }
 
 .display-inline {


### PR DESCRIPTION
Use a bigger max-height on display-visible since the code editor can get pretty tall. Need a better solution than this.
