### PR TITLE
Display stack traces for unhandled behavior errors

### DIFF
--- a/app/services/AWSLambdaServiceImpl.scala
+++ b/app/services/AWSLambdaServiceImpl.scala
@@ -62,12 +62,17 @@ class AWSLambdaServiceImpl @Inject() (val configuration: Configuration, val mode
   }
 
   private def nodeCodeFor(functionBody: String, params: Array[String], behavior: Behavior): String = {
-    val definitionParamString = (params ++ HANDLER_PARAMS ++ Array(CONTEXT_PARAM)).mkString(", ")
     val paramsFromEvent = params.indices.map(i => s"event.${invocationParamFor(i)}")
     val invocationParamsString = (paramsFromEvent ++ HANDLER_PARAMS ++ Array(s"event.$CONTEXT_PARAM")).mkString(", ")
-    s"""
-      |exports.handler = function(event, context, callback) {
-      |   var fn = function($definitionParamString) { $functionBody };
+
+    // Note: this attempts to make line numbers in the lambda script line up with those displayed in the UI
+    // Be careful changing either this or the UI line numbers
+    s"""exports.handler = function(event, context, callback) { var fn = function(
+      |     ${params.mkString(",\n")},
+      |     ${(HANDLER_PARAMS ++ Array(CONTEXT_PARAM)).mkString(", ")}
+      |   ) {
+      |     $functionBody
+      |   };
       |   var $ON_SUCCESS_PARAM = function(result) {
       |     callback(null, { "result": result === undefined ? null : result });
       |   };


### PR DESCRIPTION
- translated to hide lambda implementation details
- should show line numbers that match those in the UI (for behaviors saved after this)

Output looks like:

![image](https://cloud.githubusercontent.com/assets/266051/15860058/8f7fda6c-2c95-11e6-94b4-67ed4f715788.png)
