### PR TITLE
Now that we are saving slack profiles for all users, need to be more selective about what token we use to grab channel history

### DIFF
--- a/app/models/accounts/OAuth2Token.scala
+++ b/app/models/accounts/OAuth2Token.scala
@@ -87,7 +87,7 @@ object OAuth2Token {
       join(tokens).on(_.providerKey === _.providerKey).
       map { case(profile, token) => token }.
       filter(_.maybeSlackScopes.isDefined).
-      filterNot(_.maybeSlackScopes === "identify")
+      filterNot(_.maybeSlackScopes === "identity.basic")
   }
   val allFullForSlackTeamIdQuery = Compiled(uncompiledAllFullForSlackTeamIdQuery _)
 

--- a/app/services/SlackService.scala
+++ b/app/services/SlackService.scala
@@ -140,10 +140,7 @@ class SlackService @Inject() (
     val profile = messageContext.profile
     for {
       maybeTeam <- Team.find(profile.teamId)
-      maybeSlackProfile <- SlackProfileQueries.allFor(profile.slackTeamId).map(_.headOption)
-      maybeOAuthToken <- maybeSlackProfile.map { profile =>
-        OAuth2Token.findByLoginInfo(profile.loginInfo)
-      }.getOrElse(DBIO.successful(None))
+      maybeOAuthToken <- OAuth2Token.maybeFullForSlackTeamId(profile.slackTeamId)
       maybeUserClient <- DBIO.successful(maybeOAuthToken.map { token =>
         SlackApiClient(token.accessToken)
       })


### PR DESCRIPTION
- this should fix remember command in prod
