### PR TITLE
Remove ?justSaved=true from the browser history when appropriate

### DIFF
--- a/app/assets/javascripts/behavior_editor.jsx
+++ b/app/assets/javascripts/behavior_editor.jsx
@@ -454,10 +454,21 @@ var BehaviorEditor = React.createClass({
     });
   },
 
+  resetURL: function() {
+    var path = window.location.pathname;
+    var qps = window.location.search
+      .replace(/^\?/, '')
+      .split('&')
+      .filter(function(qp) { return qp !== 'justSaved=true'; })
+      .join('&');
+    window.history.replaceState({}, "", path + (qps ? '?' + qps : ''));
+  },
+
   componentDidUpdate: function() {
     // Note that calling setState on every update triggers an infinite loop
     if (this.state.justSaved) {
       this.setState({ justSaved: false });
+      this.resetURL();
     }
   },
 


### PR DESCRIPTION
Silently remove the justSaved=true query param from the browser's history after it's no longer true.
