### PR TITLE
Change regex to capture a wider variety of errors from lambda logs

### DIFF
--- a/app/models/bots/BehaviorVersion.scala
+++ b/app/models/bots/BehaviorVersion.scala
@@ -119,7 +119,7 @@ case class BehaviorVersion(
   }
 
   private def maybeDetailedErrorInfoIn(logResult: String): Option[String] = {
-    val logRegex = """(?s).*\n.*\t.*\t(Error:.*)\n[^\n]*\nEND.*""".r
+    val logRegex = """(?s).*\n.*\t.*\t(\S*Error:.*)\n[^\n]*\nEND.*""".r
     logRegex.findFirstMatchIn(logResult).flatMap(_.subgroups.headOption).map(translateFromLambdaErrorDetails)
   }
 


### PR DESCRIPTION
- now displays the ".length not a function" case
