### PR TITLE
Move the JS routes helper inside the <html> document

### DIFF
--- a/app/views/edit.scala.html
+++ b/app/views/edit.scala.html
@@ -8,13 +8,11 @@
 @import play.filters.csrf._
 @import play.api.libs.json._
 
-@helper.javascriptRouter("jsRoutes")(
-  routes.javascript.ApplicationController.regexValidationErrorsFor,
-  routes.javascript.ApplicationController.versionInfoFor
-)
-
 @main("Ellipsis behavior editor", maybeUser) {
-
+  @helper.javascriptRouter("jsRoutes")(
+    routes.javascript.ApplicationController.regexValidationErrorsFor,
+    routes.javascript.ApplicationController.versionInfoFor
+  )
   <div id="content" class="content">
     <div>
       <div id="editorContainer"></div>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -4,7 +4,6 @@
     )(content: Html)(implicit messages: Messages, r: RequestHeader)
 
 @import helper._
-
 <!DOCTYPE html>
 <html lang="en">
   <head>


### PR DESCRIPTION
Fixes a bug where codemirror instance height was no longer auto-sized to the content.
