### PR TITLE
Track when behaviors are imported from published

### DIFF
--- a/app/export/BehaviorVersionImporter.scala
+++ b/app/export/BehaviorVersionImporter.scala
@@ -11,7 +11,7 @@ case class BehaviorVersionImporter(team: Team, lambdaService: AWSLambdaService, 
 
   def run: DBIO[BehaviorVersion] = {
     for {
-      behavior <- BehaviorQueries.createFor(team)
+      behavior <- BehaviorQueries.createFor(team, data.config.map(_.publishedId))
       version <- BehaviorVersionQueries.createFor(behavior, lambdaService, data)
     } yield version
 

--- a/app/export/BehaviorVersionZipImporter.scala
+++ b/app/export/BehaviorVersionZipImporter.scala
@@ -41,7 +41,8 @@ case class BehaviorVersionZipImporter(team: Team, lambdaService: AWSLambdaServic
         strings.getOrElse("function.js", ""),
         strings.getOrElse("response.md", ""),
         strings.getOrElse("params.json", ""),
-        strings.getOrElse("triggers.json", "")
+        strings.getOrElse("triggers.json", ""),
+        strings.getOrElse("config.json", "")
       )
 
     BehaviorVersionImporter(team, lambdaService, data).run

--- a/app/models/bots/builtins/RememberBehavior.scala
+++ b/app/models/bots/builtins/RememberBehavior.scala
@@ -16,7 +16,7 @@ case class RememberBehavior(messageContext: MessageContext, lambdaService: AWSLa
       messages <- messageContext.recentMessages
       qaExtractor <- DBIO.successful(QuestionAnswerExtractor(messages))
       maybeBehavior <- maybeTeam.map { team =>
-        BehaviorQueries.createFor(team).map(Some(_))
+        BehaviorQueries.createFor(team, None).map(Some(_))
       }.getOrElse(DBIO.successful(None))
       maybeBehaviorVersion <- maybeBehavior.map { behavior =>
         BehaviorVersionQueries.createFor(behavior).flatMap { behaviorVersion =>

--- a/app/views/publishedBehaviors.scala.html
+++ b/app/views/publishedBehaviors.scala.html
@@ -1,7 +1,8 @@
 @(
   maybeUser: Option[models.accounts.User],
   team: Team,
-  behaviorVersions: Seq[json.EditorFormat.BehaviorVersionData]
+  behaviorVersions: Seq[json.EditorFormat.BehaviorVersionData],
+  alreadyImportedIds: Seq[String]
   )(implicit messages: Messages, r: RequestHeader)
 
 @import helper._
@@ -23,6 +24,9 @@
           <input type="hidden" name="teamId" value="@team.id"/>
           <input type="hidden" name="dataJson" value="@Json.toJson(ea).toString">
           <input type="submit" value="Import"/>
+          @if(ea.config.exists { c => alreadyImportedIds.contains(c.publishedId) }) {
+            <span>(already imported)</span>
+          }
         </form>
       }
 

--- a/conf/evolutions/default/18.sql
+++ b/conf/evolutions/default/18.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+
+ALTER TABLE behaviors ADD COLUMN imported_id TEXT;
+
+# --- !Downs
+
+ALTER TABLE behaviors DROP COLUMN imported_id;

--- a/test/BehaviorVersionSpec.scala
+++ b/test/BehaviorVersionSpec.scala
@@ -16,7 +16,7 @@ class BehaviorVersionSpec extends PlaySpec with DBMixin {
     "should load the current version" in {
       withDatabase { db =>
         val team = runNow(db, Team(IDs.next, "").save)
-        val behavior = runNow(db, BehaviorQueries.createFor(team))
+        val behavior = runNow(db, BehaviorQueries.createFor(team, None))
         val firstVersion = runNow(db, BehaviorVersionQueries.createFor(behavior))
         reloadBehavior(db, behavior).maybeCurrentVersionId mustBe Some(firstVersion.id)
         val secondVersion = runNow(db, BehaviorVersionQueries.createFor(behavior))
@@ -29,7 +29,7 @@ class BehaviorVersionSpec extends PlaySpec with DBMixin {
         val firstCode = Some("first code")
         val secondCode = Some("second code")
         val team = runNow(db, Team(IDs.next, "").save)
-        val behavior = runNow(db, BehaviorQueries.createFor(team))
+        val behavior = runNow(db, BehaviorQueries.createFor(team, None))
 
         var firstVersion = runNow(db, BehaviorVersionQueries.createFor(behavior))
         firstVersion = runNow(db, firstVersion.copy(maybeFunctionBody = firstCode).save)

--- a/test/RegexMessageTriggerSpec.scala
+++ b/test/RegexMessageTriggerSpec.scala
@@ -8,7 +8,7 @@ class RegexMessageTriggerSpec extends MessageTriggerSpec {
   def triggerFor(pattern: String, requiresBotMention: Boolean = false, isCaseSensitive: Boolean = false): RegexMessageTrigger = {
     val team = Team(IDs.next, "Team!")
     val versionId = IDs.next
-    val behavior = Behavior(IDs.next, team, Some(versionId), DateTime.now)
+    val behavior = Behavior(IDs.next, team, Some(versionId), None, DateTime.now)
     val behaviorVersion = BehaviorVersion(versionId, behavior, None, None, None, None, DateTime.now)
     RegexMessageTrigger(IDs.next, behaviorVersion, pattern, requiresBotMention, isCaseSensitive)
   }

--- a/test/TemplateMessageTriggerSpec.scala
+++ b/test/TemplateMessageTriggerSpec.scala
@@ -8,7 +8,7 @@ class TemplateMessageTriggerSpec extends MessageTriggerSpec {
   def triggerFor(template: String, requiresBotMention: Boolean = false, isCaseSensitive: Boolean = false): TemplateMessageTrigger = {
     val team = Team(IDs.next, "Team!")
     val versionId = IDs.next
-    val behavior = Behavior(IDs.next, team, Some(versionId), DateTime.now)
+    val behavior = Behavior(IDs.next, team, Some(versionId), None, DateTime.now)
     val behaviorVersion = BehaviorVersion(versionId, behavior, None, None, None, None, DateTime.now)
     TemplateMessageTrigger(IDs.next, behaviorVersion, template, requiresBotMention, isCaseSensitive)
   }


### PR DESCRIPTION
- when exporting, include config.json with a "publishedId"
- when importing, set importedId on behaviors
- display "(already imported") on published_behaviors page as a proof of concept
