### PR TITLE
Make the following endpoints not require a team id:

### DIFF
--- a/app/models/bots/MessageContext.scala
+++ b/app/models/bots/MessageContext.scala
@@ -20,7 +20,7 @@ trait MessageContext {
 
   def teachMeLinkFor(lambdaService: AWSLambdaService): String = {
     val newBehaviorLink = lambdaService.configuration.getString("application.apiBaseUrl").map { baseUrl =>
-      val path = controllers.routes.ApplicationController.newBehavior(teamId)
+      val path = controllers.routes.ApplicationController.newBehavior(Some(teamId))
       s"$baseUrl$path"
     }.get
     s"[teach me something new]($newBehaviorLink)"

--- a/conf/routes
+++ b/conf/routes
@@ -4,11 +4,11 @@
 
 # An example controller showing a sample home page
 GET         /                                         @controllers.ApplicationController.index
-GET         /published_behaviors/:teamId              @controllers.ApplicationController.publishedBehaviors(teamId: String)
-GET         /new_behavior/:teamId                     @controllers.ApplicationController.newBehavior(teamId: String)
+GET         /published_behaviors                      @controllers.ApplicationController.publishedBehaviors(teamId: Option[String] ?= None)
+GET         /new_behavior                             @controllers.ApplicationController.newBehavior(teamId: Option[String] ?= None)
 GET         /edit_behavior/:id                        @controllers.ApplicationController.editBehavior(id: String, justSaved: Option[Boolean] ?= None)
 GET         /export_behavior/:id                      @controllers.ApplicationController.exportBehavior(id: String)
-GET         /import_behavior_zip/:teamId              @controllers.ApplicationController.importBehaviorZip(teamId: String)
+GET         /import_behavior_zip                      @controllers.ApplicationController.importBehaviorZip(teamId: Option[String] ?= None)
 POST        /import_behavior_zip                      @controllers.ApplicationController.doImportBehaviorZip
 POST        /import_behavior                          @controllers.ApplicationController.doImportBehavior
 POST        /save_behavior                            @controllers.ApplicationController.saveBehavior


### PR DESCRIPTION
- /new_behavior
- /published_behaviors
- /import_behavior_zip

(these can still accept a teamId query param if you want)
