### PR TITLE
Quick fix to make behavior installing work for all teams

### DIFF
--- a/app/json/BehaviorCategory.scala
+++ b/app/json/BehaviorCategory.scala
@@ -1,7 +1,15 @@
 package json
 
+import models.Team
+
 case class BehaviorCategory(
                              name: String,
                              description: String,
                              behaviorVersions: Seq[BehaviorVersionData]
-                             )
+                             ) {
+
+  def copyForTeam(team: Team): BehaviorCategory = {
+    copy(behaviorVersions = behaviorVersions.map(_.copyForTeam(team)))
+  }
+
+}

--- a/app/json/BehaviorVersionData.scala
+++ b/app/json/BehaviorVersionData.scala
@@ -1,5 +1,6 @@
 package json
 
+import models.Team
 import models.accounts.User
 import models.bots.config.AWSConfigQueries
 import models.bots.triggers.MessageTriggerQueries
@@ -24,6 +25,10 @@ case class BehaviorVersionData(
                                 createdAt: Option[DateTime]
                                 ) {
   val awsConfig: Option[AWSConfigData] = config.aws
+
+  def copyForTeam(team: Team): BehaviorVersionData = {
+    copy(teamId = team.id)
+  }
 }
 
 object BehaviorVersionData {

--- a/app/services/GithubService.scala
+++ b/app/services/GithubService.scala
@@ -158,7 +158,7 @@ case class GithubService(team: Team, ws: WSClient, config: Configuration, cache:
   def publishedBehaviorCategories: Seq[BehaviorCategory] = {
     cache.getOrElse[Seq[BehaviorCategory]](GithubService.PUBLISHED_BEHAVIORS_KEY, 30.minutes) {
       Await.result(fetchPublishedBehaviorCategories, 5.seconds)
-    }
+    }.map(_.copyForTeam(team))
   }
 
 }


### PR DESCRIPTION
- didn't realize that we were caching a team id that breaks behavior installing for any other team; for now, fix up the cached results while i think about something better
