### PR TITLE
Seems like Slack silently fails to post messages > 5000 characters

### DIFF
--- a/app/models/SlackMessageFormatter.scala
+++ b/app/models/SlackMessageFormatter.scala
@@ -27,7 +27,12 @@ case class SlackMessageFormatter(client: SlackRtmClient) {
     val builder = StringBuilder.newBuilder
     val slack = new SlackRenderer(builder)
     commonmarkNodeFor(text).accept(slack)
-    builder.toString
+    val fullString = builder.toString
+    if (fullString.length > 5000) {
+      fullString.substring(0, 4960) ++ "...\n\n(truncated to 5000 characters)"
+    } else {
+      fullString
+    }
   }
 
 }


### PR DESCRIPTION
- truncate these and add a note that this has happened
