### PR TITLE
Include user info in ellipsis object, accessible to behaviors

### DIFF
--- a/app/models/bots/BehaviorResponse.scala
+++ b/app/models/bots/BehaviorResponse.scala
@@ -26,7 +26,7 @@ case class BehaviorResponse(
 
   def runCode(service: AWSLambdaService): Future[Unit] = {
     val startTime = DateTime.now
-    behaviorVersion.resultFor(parametersWithValues, service).flatMap { result =>
+    behaviorVersion.resultFor(parametersWithValues, event, service).flatMap { result =>
       val runtimeInMilliseconds = DateTime.now.toDate.getTime - startTime.toDate.getTime
       result.sendIn(event.context)
       service.models.run(

--- a/app/models/bots/BehaviorVersion.scala
+++ b/app/models/bots/BehaviorVersion.scala
@@ -122,10 +122,10 @@ case class BehaviorVersion(
 
   def functionName: String = id
 
-  def resultFor(parametersWithValues: Seq[ParameterWithValue], service: AWSLambdaService): Future[BehaviorResult] = {
+  def resultFor(parametersWithValues: Seq[ParameterWithValue], event: MessageEvent, service: AWSLambdaService): Future[BehaviorResult] = {
     for {
       envVars <- service.models.run(EnvironmentVariableQueries.allFor(team))
-      result <- service.invoke(this, parametersWithValues, envVars)
+      result <- service.invoke(this, parametersWithValues, envVars, event)
     } yield result
   }
 

--- a/app/models/bots/MessageContext.scala
+++ b/app/models/bots/MessageContext.scala
@@ -1,5 +1,6 @@
 package models.bots
 
+import com.mohiva.play.silhouette.api.LoginInfo
 import models.bots.conversations.Conversation
 import services.AWSLambdaService
 import slick.driver.PostgresDriver.api._
@@ -43,5 +44,7 @@ trait MessageContext extends Context {
   def userIdForContext: String
   val teamId: String
   val isResponseExpected: Boolean
+
+  def userInfo: DBIO[UserInfo] = UserInfo.forLoginInfo(LoginInfo(name, userIdForContext), teamId)
 
 }

--- a/app/models/bots/UserInfo.scala
+++ b/app/models/bots/UserInfo.scala
@@ -1,0 +1,58 @@
+package models.bots
+
+import com.mohiva.play.silhouette.api.LoginInfo
+import models.accounts.{LinkedAccount, User, OAuth2Token}
+import slick.dbio.DBIO
+import play.api.libs.json._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+case class LinkedInfo(loginInfo: LoginInfo, maybeOAuth2Token: Option[OAuth2Token]) {
+
+  def toJson: JsObject = {
+    var parts = Seq(
+      "externalSystem" -> JsString(loginInfo.providerID),
+      "userId" -> JsString(loginInfo.providerKey)
+    )
+    maybeOAuth2Token.foreach { oauth2Token =>
+      parts = parts ++ Seq(
+        "oauthToken" -> JsString(oauth2Token.accessToken)
+      )
+    }
+    JsObject(parts)
+  }
+
+}
+
+case class UserInfo(maybeUser: Option[User], links: Seq[LinkedInfo]) {
+
+  def toJson: JsObject = {
+    var parts: Seq[(String, JsValue)] = Seq(
+      "links" -> JsArray(links.map(_.toJson))
+    )
+    maybeUser.foreach { user =>
+      parts = parts ++ Seq("ellipsisUserId" -> JsString(user.id))
+    }
+    JsObject(parts)
+  }
+}
+
+object UserInfo {
+
+  def forLoginInfo(loginInfo: LoginInfo, teamId: String): DBIO[UserInfo] = {
+    for {
+      maybeLinkedAccount <- LinkedAccount.find(loginInfo, teamId)
+      maybeUser <- DBIO.successful(maybeLinkedAccount.map(_.user))
+      allLinkedAccounts <- maybeUser.map { user =>
+        LinkedAccount.allFor(user)
+      }.getOrElse(DBIO.successful(Seq()))
+      links <- DBIO.sequence(allLinkedAccounts.map { linkedAccount =>
+        val loginInfo = linkedAccount.loginInfo
+        OAuth2Token.findByLoginInfo(loginInfo).map { maybeOAuth2Token =>
+          LinkedInfo(loginInfo, maybeOAuth2Token)
+        }
+      })
+    } yield {
+      UserInfo(maybeUser, links)
+    }
+  }
+}

--- a/app/services/AWSLambdaConstants.scala
+++ b/app/services/AWSLambdaConstants.scala
@@ -7,6 +7,7 @@ object AWSLambdaConstants {
   val HANDLER_PARAMS = Array(ON_SUCCESS_PARAM, ON_ERROR_PARAM)
   val INVOCATION_TIMEOUT_SECONDS = 10
   val TOKEN_KEY = "token"
+  val USER_INFO_KEY = "userInfo"
   val ENV_KEY = "env"
   val API_BASE_URL_KEY = "apiBaseUrl"
   val RESULT_KEY = "successResult"

--- a/app/services/AWSLambdaService.scala
+++ b/app/services/AWSLambdaService.scala
@@ -3,7 +3,7 @@ package services
 import com.amazonaws.services.lambda.AWSLambdaAsyncClient
 import models.bots.config.AWSConfig
 import models.{EnvironmentVariable, Models}
-import models.bots.{BehaviorResult, ParameterWithValue, BehaviorVersion}
+import models.bots.{MessageEvent, BehaviorResult, ParameterWithValue, BehaviorVersion}
 import play.api.Configuration
 
 import scala.concurrent.Future
@@ -15,7 +15,12 @@ trait AWSLambdaService extends AWSService {
 
   val client: AWSLambdaAsyncClient
 
-  def invoke(behaviorVersion: BehaviorVersion, parametersWithValues: Seq[ParameterWithValue], environmentVariables: Seq[EnvironmentVariable]): Future[BehaviorResult]
+  def invoke(
+              behaviorVersion: BehaviorVersion,
+              parametersWithValues: Seq[ParameterWithValue],
+              environmentVariables: Seq[EnvironmentVariable],
+              event: MessageEvent
+              ): Future[BehaviorResult]
 
   def deleteFunction(functionName: String): Unit
   def deployFunctionFor(behaviorVersion: BehaviorVersion, functionBody: String, params: Array[String], maybeAWSConfig: Option[AWSConfig]): Future[Unit]


### PR DESCRIPTION
Currently includes:
- ellipsisUserId (if any)
- link to external systems of form:

```
links: [
 { externalSystem: "slack", userId: "U12345678", oauthToken: "1234567890abcdefghijklmnop" },
  ...
]
```
