### PR TITLE
Some fixes to make scheduled messages and noResponse() behave better:

### DIFF
--- a/app/actors/ScheduledMessageActor.scala
+++ b/app/actors/ScheduledMessageActor.scala
@@ -17,7 +17,8 @@ object ScheduledMessageActor {
 
 class ScheduledMessageActor @Inject() (val models: Models, val slackService: SlackService) extends Actor {
 
-  val tick = context.system.scheduler.schedule(Duration.Zero, 1 minute, self, "tick")
+  // initial delay of 1 minute so that, in the case of errors & actor restarts, it doesn't hammer external APIs
+  val tick = context.system.scheduler.schedule(1 minute, 1 minute, self, "tick")
 
   override def postStop() = {
     tick.cancel()

--- a/app/models/bots/BehaviorResult.scala
+++ b/app/models/bots/BehaviorResult.scala
@@ -55,6 +55,10 @@ case class NoResponseResult(logResult: AWSLambdaLogResult) extends BehaviorResul
 
   def text: String = ""
 
+  override def sendIn(context: MessageContext): Unit = {
+    // do nothing
+  }
+
 }
 
 case class UnhandledErrorResult(logResult: AWSLambdaLogResult) extends BehaviorResultWithLogResult {

--- a/app/models/bots/SlackMessageContext.scala
+++ b/app/models/bots/SlackMessageContext.scala
@@ -43,7 +43,10 @@ case class SlackMessageContext(
 
   def sendMessage(unformattedText: String)(implicit ec: ExecutionContext): Unit = {
     val formattedText = SlackMessageFormatter(client).bodyTextFor(unformattedText)
-    client.apiClient.postChatMessage(message.channel, formattedText, asUser = Some(true))
+    // The Slack API considers sending an empty message to be an error rather than a no-op
+    if (formattedText.nonEmpty) {
+      client.apiClient.postChatMessage(message.channel, formattedText, asUser = Some(true))
+    }
   }
 
   override def recentMessages: DBIO[Seq[String]] = {


### PR DESCRIPTION
- make noResponse() a no-op, rather than sending empty messages, which triggers slack API errors
- add an initial delay to the scheduled message actor so that, in the case of repeated errors, it doesn't hammer external APIs like slack
