### PR TITLE
Added a basic admin mode so we can access other teams' pages

### DIFF
--- a/app/models/Team.scala
+++ b/app/models/Team.scala
@@ -46,15 +46,16 @@ object Team {
   }
 
   def find(id: String, user: User): DBIO[Option[Team]] = {
-    find(id).map { maybeTeam =>
-      maybeTeam.flatMap { team =>
-        if (user.canAccess(team)) {
-          Some(team)
-        } else {
-          None
-        }
+    for {
+      maybeTeam <- find(id)
+      canAccess <- maybeTeam.map { team =>
+        user.canAccess(team)
+      }.getOrElse(DBIO.successful(false))
+    } yield if (canAccess) {
+        maybeTeam
+      } else {
+        None
       }
-    }
   }
 
   def findForToken(tokenId: String): DBIO[Option[Team]] = {

--- a/app/utils/ErrorHandler.scala
+++ b/app/utils/ErrorHandler.scala
@@ -44,7 +44,6 @@ class ErrorHandler @Inject() (
         views.html.notFound(
           None,
           None,
-          None,
           maybeNonEmptyMessage
         )
       )

--- a/app/views/addToSlack.scala.html
+++ b/app/views/addToSlack.scala.html
@@ -1,11 +1,10 @@
 @(
-    maybeUser: Option[models.accounts.User],
     scopes: String,
     clientId: String,
     redirectUrl: String
     )(implicit r: RequestHeader, m: Messages)
 
-@main("Add to Slack", maybeUser, None) {
+@main("Add to Slack", None) {
 
   <div id="content" class="content">
     <div class="container ptxxxxl">

--- a/app/views/authenticated.scala.html
+++ b/app/views/authenticated.scala.html
@@ -2,7 +2,7 @@
   message: String
   )(implicit messages: Messages, r: RequestHeader)
 
-@main("Authenticated", None, None) {
+@main("Authenticated", None) {
 
   <div id="content" class="content">
     <div class="bg-blue-medium pvxxl border-emphasis-bottom border-blue bg-large-logo">

--- a/app/views/behaviorTabs.scala.html
+++ b/app/views/behaviorTabs.scala.html
@@ -1,6 +1,6 @@
 @(
   activeTab: String,
-  team: Team
+  teamAccess: models.accounts.UserTeamAccess
 )
 
 @tabClassFor(tabId: String) = @{
@@ -14,12 +14,12 @@
   <div class="container">
     <div class="columns ptl">
       <div class="column column-right align-r">
-        <a href='@routes.ApplicationController.newBehavior()' class="button">Teach Ellipsis something new</a>
+        <a href='@routes.ApplicationController.newBehavior(teamAccess.maybeAdminAccessToTeamId)' class="button">Teach Ellipsis something new</a>
       </div>
       <div class="column mtl">
         <div class="tabs">
-          <a class='@tabClassFor("view")' href="@routes.ApplicationController.index()">View your behaviors</a>
-          <a class='@tabClassFor("install")' href="@routes.ApplicationController.installBehaviors()">Install behaviors</a>
+          <a class='@tabClassFor("view")' href="@routes.ApplicationController.index(teamAccess.maybeAdminAccessToTeamId)">View your behaviors</a>
+          <a class='@tabClassFor("install")' href="@routes.ApplicationController.installBehaviors(teamAccess.maybeAdminAccessToTeamId)">Install behaviors</a>
         </div>
       </div>
     </div>

--- a/app/views/edit.scala.html
+++ b/app/views/edit.scala.html
@@ -1,6 +1,5 @@
 @(
-  maybeUser: Option[models.accounts.User],
-  maybeTeam: Option[models.Team],
+  teamAccess: models.accounts.UserTeamAccess,
   json: String,
   envVariablesJson: String,
   oauth2ApplicationsJson: String,
@@ -9,9 +8,8 @@
     )(implicit messages: Messages, r: RequestHeader)
 
 @import play.filters.csrf._
-@import play.api.libs.json._
 
-@main("Ellipsis behavior editor", maybeUser, maybeTeam) {
+@main("Ellipsis behavior editor", Some(teamAccess)) {
   @helper.javascriptRouter("jsRoutes")(
     routes.javascript.ApplicationController.regexValidationErrorsFor,
     routes.javascript.ApplicationController.versionInfoFor,

--- a/app/views/editOAuth2Application.scala.html
+++ b/app/views/editOAuth2Application.scala.html
@@ -1,12 +1,11 @@
 @(
-  maybeUser: Option[models.accounts.User],
-  application: models.accounts.OAuth2Application,
-  team: models.Team
+  teamAccess: models.accounts.UserTeamAccess,
+  application: models.accounts.OAuth2Application
   )(implicit messages: Messages, r: RequestHeader)
 
 @import helper._
 
-@main("Configure API access", maybeUser, Some(team)) {
+@main("Configure API access", Some(teamAccess)) {
 
   <div id="content" class="content">
     <div class="container ptxxxxl">
@@ -15,7 +14,7 @@
       <form action="@routes.ApplicationController.saveOAuth2Application()" method="POST">
         @CSRF.formField
         <input type="hidden" name="id" value="@application.id"/>
-        <input type="hidden" name="teamId" value="@team.id"/>
+        <input type="hidden" name="teamId" value="@teamAccess.maybeTargetTeam.map(_.id)"/>
         <input type="hidden" name="apiId" value="@application.api.id"/>
 
         <div class="columns">

--- a/app/views/importBehaviorZip.scala.html
+++ b/app/views/importBehaviorZip.scala.html
@@ -1,11 +1,10 @@
 @(
-  maybeUser: Option[models.accounts.User],
-  team: models.Team
+  teamAccess: models.accounts.UserTeamAccess
   )(implicit messages: Messages, r: RequestHeader)
 
 @import helper._
 
-@main("Import a behavior", maybeUser, Some(team)) {
+@main("Import a behavior", Some(teamAccess)) {
 
   <div id="content" class="content">
     <div class="container ptxxxxl">
@@ -17,7 +16,7 @@
 
       <form action="@routes.ApplicationController.doImportBehaviorZip()" method="POST" enctype="multipart/form-data">
         @CSRF.formField
-        <input type="hidden" name="teamId" value="@team.id"/>
+        <input type="hidden" name="teamId" value="@teamAccess.maybeTargetTeam.map(_.id)"/>
         <input type="file" name="zipFile">
         <div class="actions">
           <input type="submit" value="Import"/>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,18 +1,17 @@
 @(
-  maybeUser: Option[models.accounts.User],
-  team: Team,
+  teamAccess: models.accounts.UserTeamAccess,
   behaviorVersions: Seq[json.BehaviorVersionData]
 )(implicit messages: Messages, r: RequestHeader)
 
 @import play.api.libs.json._
 @import json.Formatting._
 
-@main("Ellipsis behavior editor", maybeUser, Some(team)) {
+@main("Ellipsis behavior editor", Some(teamAccess)) {
   @helper.javascriptRouter("jsRoutes")(
     routes.javascript.ApplicationController.editBehavior
   )
   <div id="content" class="content">
-    @views.html.behaviorTabs("view", team)
+    @views.html.behaviorTabs("view", teamAccess)
 
     <div class="bg-white">
       <div class="container pvxxl mobile-ptm">

--- a/app/views/intro.scala.html
+++ b/app/views/intro.scala.html
@@ -1,6 +1,5 @@
 @(
-  maybeUser: Option[models.accounts.User],
-  team: Team,
+  teamAccess: models.accounts.UserTeamAccess,
   behaviorCategories: Seq[json.BehaviorCategory],
   installedBehaviors: Seq[json.InstalledBehaviorData]
   )(implicit messages: Messages, r: RequestHeader)
@@ -9,7 +8,7 @@
 @import play.api.libs.json._
 @import json.Formatting._
 
-@main("Welcome to Ellipsis", maybeUser, Some(team), "intro") {
+@main("Welcome to Ellipsis", Some(teamAccess), "intro") {
   @helper.javascriptRouter("jsRoutes")(
     routes.javascript.ApplicationController.doImportBehavior,
     routes.javascript.ApplicationController.editBehavior
@@ -37,7 +36,7 @@
             <div class="arrow-right mobile-display-none"></div>
           </h4>
 
-          <h4>Or else <a href='@routes.ApplicationController.newBehavior()'>teach Ellipsis something brand new.</a></h4>
+          <h4>Or else <a href='@routes.ApplicationController.newBehavior(teamAccess.maybeAdminAccessToTeamId)'>teach Ellipsis something brand new.</a></h4>
 
           <ul class="type-s list-space-s checklist type-weak">
             <li>Behaviors instruct your bot how to do repetitive or cumbersome tasks, and what

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,7 +1,6 @@
 @(
   title: String,
-  maybeUser: Option[models.accounts.User],
-  maybeTeam: Option[models.Team],
+  maybeTeamAccess: Option[models.accounts.UserTeamAccess],
   pageId: String = ""
   )(content: Html)(implicit messages: Messages, r: RequestHeader)
 
@@ -43,7 +42,7 @@
       <div class="container">
         <div class="columns columns-elastic">
           <div class="column column-expand pts pbxs">
-            <a href='@routes.ApplicationController.index()' class="link-green display-inline-block align-b" style="height: 36px">
+            <a href='@routes.ApplicationController.index(maybeTeamAccess.flatMap(_.maybeAdminAccessToTeamId))' class="link-green display-inline-block align-b" style="height: 36px">
               <span class="mobile-display-none">
                 <svg role="img" aria-label="Ellipsis"
                 version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
@@ -114,9 +113,9 @@
             </a>
 
             <a class="link-blue-light display-inline-block align-button mhm"
-              href='@routes.ApplicationController.index()'>Behaviors</a>
+              href='@routes.ApplicationController.index(maybeTeamAccess.flatMap(_.maybeAdminAccessToTeamId))'>Behaviors</a>
           </div>
-          @maybeUser.map { _ =>
+          @maybeTeamAccess.map { teamAccess =>
             <div class="column column-shrink align-r pts pbxs">
               <form action='@routes.SocialAuthController.signOut()' method="POST" id="main-user-menu-container">
                 @CSRF.formField
@@ -154,16 +153,20 @@
                         </g>
                       </svg>
                     </span>
-                    @maybeTeam.flatMap(_.maybeNonEmptyName.map(name => {
-                      <span class="type-label display-inline-block align-t ptxs mlxs mobile-display-none">{name}</span>
-                    })).getOrElse("")
+                    @teamAccess.maybeAdminAccessToTeam.map { team =>
+                      <span class="type-label type-pink display-inline-block align-t ptxs mlxs mobile-display-none">Admin access to @team.name!!</span>
+                    }.getOrElse {
+                      @teamAccess.maybeTargetTeam.flatMap(_.maybeNonEmptyName.map(name => {
+                          <span class="type-label display-inline-block align-t ptxs mlxs mobile-display-none">{name}</span>
+                      })).getOrElse("")
+                    }
                   </button>
                 </span>
                 <div class="position-relative type-black">
                   <ul class="type-s popup popup-dropdown-menu popup-dropdown-menu-right fade-in" id="main-user-menu" style="display: none">
-                    @maybeTeam.flatMap(_.maybeNonEmptyName.map(name => {
+                    @teamAccess.loggedInTeam.maybeNonEmptyName.map(name => {
                       <li class='type-disabled align-l phl pvs display-ellipsis'>Signed into {name}</li>
-                    })).getOrElse("")
+                    }).getOrElse("")
                     <li><button type="submit" class="button-dropdown-item">Sign out</button></li>
                   </ul>
                 </div>

--- a/app/views/newOAuth2Application.scala.html
+++ b/app/views/newOAuth2Application.scala.html
@@ -1,12 +1,11 @@
 @(
-  maybeUser: Option[models.accounts.User],
-  team: models.Team,
+  teamAccess: models.accounts.UserTeamAccess,
   apis: Seq[models.accounts.OAuth2Api]
   )(implicit messages: Messages, r: RequestHeader)
 
 @import helper._
 
-@main("Configure API access", maybeUser, Some(team)) {
+@main("Configure API access", Some(teamAccess)) {
 
   <div id="content" class="content">
     <div class="container ptxxxxl">
@@ -14,7 +13,7 @@
 
       <form action="@routes.ApplicationController.saveOAuth2Application()" method="POST">
         @CSRF.formField
-        <input type="hidden" name="teamId" value="@team.id"/>
+        <input type="hidden" name="teamId" value="@teamAccess.maybeTargetTeam.map(_.id)"/>
 
         <div class="columns">
           <div class="column column-one-third align-r">Configure for API access to:</div>

--- a/app/views/notFound.scala.html
+++ b/app/views/notFound.scala.html
@@ -1,12 +1,11 @@
 @(
-  maybeUser: Option[models.accounts.User],
-  maybeTeam: Option[models.Team],
+  maybeTeamAccess: Option[models.accounts.UserTeamAccess],
   maybeHeading: Option[String],
   maybeErrorMessage: Option[String],
   maybeSignInLink: Option[Call] = None
 )(implicit messages: Messages, r: RequestHeader)
 
-@main(maybeHeading.getOrElse("Page not found"), maybeUser, None) {
+@main(maybeHeading.getOrElse("Page not found"), maybeTeamAccess) {
 
 <div id="content" class="content">
   <div class="bg-pink border-emphasis-bottom border-pink bg-large-logo">
@@ -38,8 +37,8 @@
           </p>
           <p>
             It may have been removed,
-            or you may not have access to it @maybeTeam.map { team =>
-              while signed into this team (<b>@team.name</b>)
+            or you may not have access to it @maybeTeamAccess.map { teamAccess =>
+              while signed into this team (<b>@teamAccess.loggedInTeam.name</b>)
             } @maybeSignInLink.map { link =>
               . You may want to try <a href="@link">signing in with a different team</a> if you have more than one account.
             }

--- a/app/views/oAuth2Api.scala.html
+++ b/app/views/oAuth2Api.scala.html
@@ -1,12 +1,11 @@
 @(
-  maybeUser: Option[models.accounts.User],
-  maybeApi: Option[models.accounts.OAuth2Api],
-  maybeTeam: Option[models.Team]
+  teamAccess: models.accounts.UserTeamAccess,
+  maybeApi: Option[models.accounts.OAuth2Api]
   )(implicit messages: Messages, r: RequestHeader)
 
 @import helper._
 
-@main("Configure an external API", maybeUser, maybeTeam) {
+@main("Configure an external API", Some(teamAccess)) {
 
   <div id="content" class="content">
     <div class="container ptxxxxl">
@@ -14,7 +13,7 @@
 
       <form action="@routes.ApplicationController.saveOAuth2Api()" method="POST">
         @CSRF.formField
-        @maybeTeam.map { team =>
+        @teamAccess.maybeTargetTeam.map { team =>
           <input type="hidden" name="teamId" value="@team.id"/>
         }
         @maybeApi.map { api =>

--- a/app/views/publishedBehaviors.scala.html
+++ b/app/views/publishedBehaviors.scala.html
@@ -1,6 +1,5 @@
 @(
-  maybeUser: Option[models.accounts.User],
-  team: Team,
+  teamAccess: models.accounts.UserTeamAccess,
   behaviorCategories: Seq[json.BehaviorCategory],
   installedBehaviors: Seq[json.InstalledBehaviorData]
   )(implicit messages: Messages, r: RequestHeader)
@@ -9,13 +8,13 @@
 @import play.api.libs.json._
 @import json.Formatting._
 
-@main("Published behaviors", maybeUser, Some(team)) {
+@main("Published behaviors", Some(teamAccess)) {
   @helper.javascriptRouter("jsRoutes")(
     routes.javascript.ApplicationController.doImportBehavior,
     routes.javascript.ApplicationController.editBehavior
   )
   <div id="content" class="content">
-    @views.html.behaviorTabs("install", team)
+    @views.html.behaviorTabs("install", teamAccess)
     <div class="bg-white">
       <div class="container pbxxl">
         <div id="importerContainer"></div>

--- a/app/views/serverError.scala.html
+++ b/app/views/serverError.scala.html
@@ -2,7 +2,7 @@
   maybeErrorId: Option[String]
 )(implicit messages: Messages, r: RequestHeader)
 
-@main("Error", None, None) {
+@main("Error", None) {
 
 <div id="content" class="content">
   <div class="bg-pink border-emphasis-bottom border-pink bg-large-logo">

--- a/app/views/signInWithSlack.scala.html
+++ b/app/views/signInWithSlack.scala.html
@@ -1,12 +1,11 @@
 @(
-    maybeUser: Option[models.accounts.User],
+    maybeTeamAccess: Option[models.accounts.UserTeamAccess],
     scopes: String,
     clientId: String,
-    redirectUrl: String,
-    maybeTeam: Option[Team] = None
+    redirectUrl: String
     )(implicit r: RequestHeader, m: Messages)
 
-@main("Sign in with Slack", maybeUser, maybeTeam) {
+@main("Sign in with Slack", maybeTeamAccess) {
 
   <div id="content" class="content">
     <div class="container ptxxxxl">
@@ -14,7 +13,7 @@
       <h1>Sign in to Ellipsis</h1>
 
       <p>You need to identify yourself to make changes to the bot. Click the button to sign
-      in with your @maybeTeam.map(_.name).getOrElse("team") Slack account.</p>
+      in with your @maybeTeamAccess.flatMap(_.maybeTargetTeam.map(_.name)).getOrElse("team") Slack account.</p>
 
       <p>
         @signInWithSlackButton(scopes, clientId, redirectUrl)


### PR DESCRIPTION
- admin abilities is currently based on if you are on the Ellipsis Slack team (we can restrict it further if nec)
- better factored all the various access logic into a new UserTeamAccess class, that is used all over the place
