### PR TITLE
Get rid of the behavior migration code

### DIFF
--- a/app/models/bots/BehaviorVersion.scala
+++ b/app/models/bots/BehaviorVersion.scala
@@ -179,16 +179,6 @@ case class BehaviorVersion(
     }
   }
 
-  def copyWithNewFormat: BehaviorVersion = {
-    val maybeNewFunctionBody = maybeFunctionBody.map { body =>
-      body.
-        replaceAll("onSuccess", "ellipsis.success").
-        replaceAll("onError", "ellipsis.error").
-        replaceAll("new AWS", "new ellipsis.AWS")
-    }
-    this.copy(maybeFunctionBody = maybeNewFunctionBody)
-  }
-
   def save: DBIO[BehaviorVersion] = BehaviorVersionQueries.save(this)
 
   def toRaw: RawBehaviorVersion = {

--- a/app/views/admin/listLambdaFunctions.scala.html
+++ b/app/views/admin/listLambdaFunctions.scala.html
@@ -14,10 +14,6 @@
 </ul>
 
 <p>@currentFunctions.length current functions:</p>
-<form action="@routes.AdminController.fixUpAllVersions()" method="POST">
-  @CSRF.formField
-  <input type="submit" value="Fix all versions"/>
-</form>
 <ul>
   @currentFunctions.map { fn =>
     <li>

--- a/conf/routes
+++ b/conf/routes
@@ -38,7 +38,6 @@ GET         /authenticated/:message                   @controllers.APIAccessCont
 
 GET         /admin/lambda_functions                   @controllers.AdminController.lambdaFunctions()
 POST        /admin/redeploy/:versionId                @controllers.AdminController.redeploy(versionId: String)
-POST        /admin/fix_up_all_versions                @controllers.AdminController.fixUpAllVersions
 
 #POST        /authenticate/credentials        controllers.CredentialsAuthController.authenticate
 #POST        /signUp                          controllers.SignUpController.signUp


### PR DESCRIPTION
- might as well keep the redeploy lambda function stuff
