### PR TITLE
Use memcached for caching

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,8 @@ libraryDependencies ++= Seq(
   "com.atlassian.commonmark" % "commonmark" % "0.6.0",
   "com.atlassian.commonmark" % "commonmark-ext-gfm-strikethrough" % "0.6.0",
   "com.atlassian.commonmark" % "commonmark-ext-autolink" % "0.6.0",
-  "com.joestelmach" % "natty" % "0.11"
+  "com.joestelmach" % "natty" % "0.11",
+  "com.github.mumoshu" %% "play2-memcached-play24" % "0.7.0"
 )
 
 javaOptions in Test += "-Dconfig.file=conf/test.conf"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -67,6 +67,9 @@ application.apiBaseUrl = ${API_BASE_URL}
 include "aws.conf"
 include "modules.conf"
 include "github.conf"
+include "cache.conf"
+
+memcached.host="127.0.0.1:11211"
 
 github.cacheTimeoutSeconds=30
 

--- a/conf/cache.conf
+++ b/conf/cache.conf
@@ -1,0 +1,8 @@
+play.modules.enabled+="com.github.mumoshu.play2.memcached.MemcachedModule"
+
+# To avoid conflict with play2-memcached's Memcached-based cache module
+play.modules.disabled+="play.api.cache.EhCacheModule"
+
+# Well-known configuration provided by Play
+play.modules.cache.defaultCache=default
+play.modules.cache.bindCaches=["db-cache", "user-cache", "session-cache"]

--- a/conf/docker.conf
+++ b/conf/docker.conf
@@ -37,5 +37,9 @@ include "auth.conf"
 include "aws.conf"
 include "modules.conf"
 include "github.conf"
+include "cache.conf"
+
+memcached.host="changeme"
+memcached.host=${?MEMCACHED_ENDPOINT}
 
 play.http.filters=filters.Filters


### PR DESCRIPTION
- ready for elasticache in prod
- this config requires running memcached locally (we could use the default cache in dev and memcache in prod, but for now i'm going to keep the configs similar)
