### PR TITLE
Added an optional behaviorId param to /new_oauth2_application

### DIFF
--- a/app/assets/javascripts/application_editor/index.jsx
+++ b/app/assets/javascripts/application_editor/index.jsx
@@ -20,7 +20,8 @@ define(function(require) {
       csrfToken: React.PropTypes.string.isRequired,
       teamId: React.PropTypes.string.isRequired,
       callbackUrl: React.PropTypes.string,
-      applicationId: React.PropTypes.string
+      applicationId: React.PropTypes.string,
+      behaviorId: React.PropTypes.string
     },
 
     getInitialState: function() {
@@ -154,6 +155,15 @@ define(function(require) {
       });
     },
 
+    renderBehaviorId: function() {
+      var id = this.props.behaviorId;
+      if (id && id.length > 0) {
+        return (<input type="hidden" name="behaviorId" value={id} />);
+      } else {
+        return null;
+      }
+    },
+
     render: function() {
       return (
         <form action={jsRoutes.controllers.ApplicationController.saveOAuth2Application().url} method="POST">
@@ -161,6 +171,7 @@ define(function(require) {
           <input type="hidden" name="apiId" value={this.getApplicationApiId()} />
           <input type="hidden" name="id" value={this.props.applicationId} />
           <input type="hidden" name="teamId" value={this.props.teamId} />
+          {this.renderBehaviorId()}
 
           <div className="bg-light">
             <div className="container pbm">

--- a/app/views/newOAuth2Application.scala.html
+++ b/app/views/newOAuth2Application.scala.html
@@ -2,7 +2,8 @@
   teamAccess: models.accounts.UserTeamAccess,
   apis: Seq[json.OAuth2ApiData],
   applicationId: String,
-  maybeApiId: Option[String]
+  maybeApiId: Option[String],
+  maybeBehaviorId: Option[String]
   )(implicit messages: Messages, r: RequestHeader)
 
 @import play.filters.csrf._
@@ -21,7 +22,8 @@
         apis: @Html(Json.toJson(apis).toString),
         callbackUrl: "@routes.APIAccessController.linkCustomOAuth2Service(applicationId, None, None, None).absoluteURL(secure = true)",
         applicationId: "@applicationId",
-        applicationApiId: "@maybeApiId.getOrElse("")"
+        applicationApiId: "@maybeApiId.getOrElse("")",
+        behaviorId: "@maybeBehaviorId.getOrElse("")"
       };
     </script>
     <script data-main='@RemoteAssets.getUrl("javascripts/application_editor/loader.js")' src='@RemoteAssets.getUrl("lib/requirejs/require.min.js")'></script>

--- a/conf/routes
+++ b/conf/routes
@@ -20,7 +20,7 @@ GET         /version_info/:behaviorId                 @controllers.ApplicationCo
 POST        /test_behavior_version                    @controllers.ApplicationController.testBehaviorVersion
 POST        /submit_environment_variables             @controllers.ApplicationController.submitEnvironmentVariables
 GET         /list_oauth2_applications                 @controllers.ApplicationController.listOAuth2Applications(teamId: Option[String] ?= None)
-GET         /new_oauth2_application                   @controllers.ApplicationController.newOAuth2Application(apiId: Option[String] ?= None, teamId: Option[String] ?= None)
+GET         /new_oauth2_application                   @controllers.ApplicationController.newOAuth2Application(apiId: Option[String] ?= None, teamId: Option[String] ?= None, behaviorId: Option[String] ?= None)
 GET         /edit_oauth2_application/:id              @controllers.ApplicationController.editOAuth2Application(id: String, teamId: Option[String] ?= None)
 POST        /save_oauth2_application                  @controllers.ApplicationController.saveOAuth2Application
 GET         /new_oauth2_api                           @controllers.ApplicationController.newOAuth2Api(teamId: Option[String] ?= None)


### PR DESCRIPTION
- send user back to behavior editor for that behavior if present, after save
