### PR TITLE
Clean up BehaviorResult-related code:

### DIFF
--- a/app/controllers/APIController.scala
+++ b/app/controllers/APIController.scala
@@ -85,6 +85,7 @@ class APIController @Inject() (
             })
           result <- maybeEvent.map { event =>
             DBIO.from(eventHandler.handle(event)).map { result =>
+              result.sendIn(event.context)
               Ok(result.fullText)
             }
           }.getOrElse(DBIO.successful(NotFound("")))

--- a/app/models/bots/BehaviorResponse.scala
+++ b/app/models/bots/BehaviorResponse.scala
@@ -26,11 +26,10 @@ case class BehaviorResponse(
     parametersWithValues.forall(_.maybeValue.isDefined)
   }
 
-  def runCode(service: AWSLambdaService): Future[BehaviorResult] = {
+  def resultForFilledOut(service: AWSLambdaService): Future[BehaviorResult] = {
     val startTime = DateTime.now
     behaviorVersion.resultFor(parametersWithValues, event, service).flatMap { result =>
       val runtimeInMilliseconds = DateTime.now.toDate.getTime - startTime.toDate.getTime
-      result.sendIn(event.context)
       service.models.run(
         InvocationLogEntryQueries.createFor(
           behaviorVersion,
@@ -43,9 +42,9 @@ case class BehaviorResponse(
     }
   }
 
-  def run(service: AWSLambdaService): DBIO[BehaviorResult] = {
+  def result(service: AWSLambdaService): DBIO[BehaviorResult] = {
     if (isFilledOut) {
-      DBIO.from(runCode(service))
+      DBIO.from(resultForFilledOut(service))
     } else {
       for {
         convo <- InvokeBehaviorConversation.createFor(behaviorVersion, event.context.name, event.context.userIdForContext, activatedTrigger)
@@ -54,7 +53,7 @@ case class BehaviorResponse(
             CollectedParameterValue(p.parameter, convo, v).save
           }.getOrElse(DBIO.successful(Unit))
         })
-        result <- convo.replyFor(event, service)
+        result <- convo.resultFor(event, service)
       } yield result
     }
   }

--- a/app/models/bots/BehaviorTestReportBuilder.scala
+++ b/app/models/bots/BehaviorTestReportBuilder.scala
@@ -15,7 +15,7 @@ class BehaviorTestReportBuilder @Inject() (lambdaService: AWSLambdaService) {
     for {
       maybeResponse <- BehaviorResponse.chooseFor(event, None, Some(behaviorVersion.behavior))
       _ <- maybeResponse.map { behaviorResponse =>
-        behaviorResponse.run(lambdaService)
+        behaviorResponse.result(lambdaService)
       }.getOrElse(DBIO.successful(Unit))
     } yield {
       BehaviorTestReport(event, behaviorVersion, maybeResponse)

--- a/app/models/bots/builtins/BuiltinBehavior.scala
+++ b/app/models/bots/builtins/BuiltinBehavior.scala
@@ -12,12 +12,6 @@ trait BuiltinBehavior {
   val messageContext: MessageContext
   val lambdaService: AWSLambdaService
 
-  def run: DBIO[BehaviorResult] = {
-    result.map { r =>
-      r.sendIn(messageContext)
-      r
-    }
-  }
   def result: DBIO[BehaviorResult]
 }
 

--- a/app/models/bots/conversations/Conversation.scala
+++ b/app/models/bots/conversations/Conversation.scala
@@ -25,7 +25,7 @@ trait Conversation {
   def updateWith(event: MessageEvent, lambdaService: AWSLambdaService): DBIO[Conversation]
   def respond(event: MessageEvent, lambdaService: AWSLambdaService): DBIO[BehaviorResult]
 
-  def replyFor(event: MessageEvent, lambdaService: AWSLambdaService): DBIO[BehaviorResult] = {
+  def resultFor(event: MessageEvent, lambdaService: AWSLambdaService): DBIO[BehaviorResult] = {
     for {
       updatedConversation <- updateWith(event, lambdaService)
       result <- updatedConversation.respond(event, lambdaService)

--- a/app/services/SlackService.scala
+++ b/app/services/SlackService.scala
@@ -55,8 +55,11 @@ class SlackService @Inject() (
 
     client.onMessage { message =>
       if (message.user != selfId) {
-        val p = Promise[BehaviorResult]()
-        val handleMessage = eventHandler.handle(SlackMessageEvent(SlackMessageContext(client, profile, message)))
+        val p = Promise[Unit]()
+        val event = SlackMessageEvent(SlackMessageContext(client, profile, message))
+        val handleMessage = eventHandler.handle(event).map { result =>
+          result.sendIn(event.context)
+        }
         p.completeWith(handleMessage)
         val indicateTyping = Future {
           Thread.sleep(500)


### PR DESCRIPTION
- renaming
- leave sendIn() calls as late as possible to make errors easier to see and simplify code
- fixes broken "i don't know how to respond to..." cases
