### PR TITLE
To make things easier, add a link in the "you need to configure the X API" notification that specifies the desired API and recommended scope

### DIFF
--- a/app/assets/javascripts/application_editor/index.jsx
+++ b/app/assets/javascripts/application_editor/index.jsx
@@ -12,6 +12,7 @@ define(function(require) {
     propTypes: {
       apis: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
       applicationApiId: React.PropTypes.string,
+      recommendedScope: React.PropTypes.string,
       applicationName: React.PropTypes.string,
       applicationClientId: React.PropTypes.string,
       applicationClientSecret: React.PropTypes.string,
@@ -30,7 +31,7 @@ define(function(require) {
         applicationName: this.props.applicationName || "",
         applicationClientId: this.props.applicationClientId || "",
         applicationClientSecret: this.props.applicationClientSecret || "",
-        applicationScope: this.props.applicationScope || "",
+        applicationScope: this.props.applicationScope || this.props.recommendedScope || "",
         hasNamedApplication: this.props.applicationSaved || false,
         shouldRevealApplicationUrl: this.props.applicationSaved || false,
         isSaving: false

--- a/app/assets/javascripts/behavior_editor/index.jsx
+++ b/app/assets/javascripts/behavior_editor/index.jsx
@@ -290,7 +290,8 @@ return React.createClass({
         name: this.getOAuth2ApiWithId(ea.apiId).name,
         requiredApiConfig: ea,
         existingOAuth2Applications: this.getAllOAuth2Applications(),
-        onAddOAuth2Application: this.onAddOAuth2Application
+        onAddOAuth2Application: this.onAddOAuth2Application,
+        onNewOAuth2Application: this.onNewOAuth2Application
       });
     });
     var unusedApplications =
@@ -1096,9 +1097,11 @@ return React.createClass({
     }), this.resetNotifications);
   },
 
-  onNewOAuth2Application: function() {
+  onNewOAuth2Application: function(apiId, recommendedScope) {
     this.setState({
-      redirectValue: "newOAuth2Application"
+      redirectValue: "newOAuth2Application",
+      newOAuth2ApplicationApiId: apiId,
+      newOAuth2ApplicationRecommendedScope: recommendedScope
     }, () => { this.onSubmit(); });
   },
 
@@ -1164,7 +1167,9 @@ return React.createClass({
       versionsLoadStatus: null,
       onNextNewEnvVar: null,
       envVariableAdderPrompt: null,
-      redirectValue: ""
+      redirectValue: "",
+      newOAuth2ApplicationApiId: "",
+      newOAuth2ApplicationRecommendedScope: ""
     };
   },
 
@@ -1200,6 +1205,8 @@ return React.createClass({
           value={JSON.stringify(this.state.behavior)}
         />
         <input type="hidden" name="redirect" value={this.getRedirectValue()} />
+        <input type="hidden" name="newOAuth2ApplicationApiId" value={this.state.newOAuth2ApplicationApiId} />
+        <input type="hidden" name="newOAuth2ApplicationRecommendedScope" value={this.state.newOAuth2ApplicationRecommendedScope} />
 
         {/* Start of container */}
         <div className="container ptxl pbxxxl">

--- a/app/assets/javascripts/notification.jsx
+++ b/app/assets/javascripts/notification.jsx
@@ -98,6 +98,10 @@ define(function(require) {
       detail.onAddOAuth2Application(app);
     },
 
+    onNewOAuth2Application: function(detail, apiId, recommendedScope) {
+      detail.onNewOAuth2Application(apiId, recommendedScope);
+    },
+
     addOAuth2ApplicationPrompt: function(detail) {
       var matchingApplication = detail.existingOAuth2Applications.find(ea => ea.apiId === detail.requiredApiConfig.apiId);
       if (matchingApplication) {
@@ -109,6 +113,19 @@ define(function(require) {
               onClick={this.onAddOAuth2Application.bind(this, detail, matchingApplication)}>
 
               Add {matchingApplication.displayName} to this behavior
+
+            </button>
+          </span>
+        );
+      } else {
+        return (
+          <span className="mhxs">
+            <button
+              type="button"
+              className="button-raw link button-s"
+              onClick={this.onNewOAuth2Application.bind(this, detail, detail.requiredApiConfig.apiId, detail.requiredApiConfig.recommendedScope)}>
+
+              Configure the {detail.name} API for this behavior
 
             </button>
           </span>

--- a/app/views/newOAuth2Application.scala.html
+++ b/app/views/newOAuth2Application.scala.html
@@ -3,6 +3,7 @@
   apis: Seq[json.OAuth2ApiData],
   applicationId: String,
   maybeApiId: Option[String],
+  maybeRecommendedScope: Option[String],
   maybeBehaviorId: Option[String]
   )(implicit messages: Messages, r: RequestHeader)
 
@@ -23,6 +24,7 @@
         callbackUrl: "@routes.APIAccessController.linkCustomOAuth2Service(applicationId, None, None, None).absoluteURL(secure = true)",
         applicationId: "@applicationId",
         applicationApiId: "@maybeApiId.getOrElse("")",
+        recommendedScope: "@maybeRecommendedScope.getOrElse("")",
         behaviorId: "@maybeBehaviorId.getOrElse("")"
       };
     </script>

--- a/conf/routes
+++ b/conf/routes
@@ -20,7 +20,7 @@ GET         /version_info/:behaviorId                 @controllers.ApplicationCo
 POST        /test_behavior_version                    @controllers.ApplicationController.testBehaviorVersion
 POST        /submit_environment_variables             @controllers.ApplicationController.submitEnvironmentVariables
 GET         /list_oauth2_applications                 @controllers.ApplicationController.listOAuth2Applications(teamId: Option[String] ?= None)
-GET         /new_oauth2_application                   @controllers.ApplicationController.newOAuth2Application(apiId: Option[String] ?= None, teamId: Option[String] ?= None, behaviorId: Option[String] ?= None)
+GET         /new_oauth2_application                   @controllers.ApplicationController.newOAuth2Application(apiId: Option[String] ?= None, recommendedScope: Option[String] ?= None, teamId: Option[String] ?= None, behaviorId: Option[String] ?= None)
 GET         /edit_oauth2_application/:id              @controllers.ApplicationController.editOAuth2Application(id: String, teamId: Option[String] ?= None)
 POST        /save_oauth2_application                  @controllers.ApplicationController.saveOAuth2Application
 GET         /new_oauth2_api                           @controllers.ApplicationController.newOAuth2Api(teamId: Option[String] ?= None)


### PR DESCRIPTION
- use this to populate the form
