### PR TITLE
Scope API tokens by user, not team

### DIFF
--- a/app/assets/javascripts/api_token_generator/index.jsx
+++ b/app/assets/javascripts/api_token_generator/index.jsx
@@ -111,7 +111,6 @@ define(function(require) {
                 </p>
 
                 <ul>
-                  <li><code className="box-code-example">teamId:</code> your team ID — <code className="box-code-example">{this.props.teamId}</code></li>
                   <li><code className="box-code-example">message:</code> a message which would normally trigger a behavior</li>
                   <li><code className="box-code-example">responseContext:</code> use <code className="box-code-example">slack</code> to see a response in Slack</li>
                   <li><code className="box-code-example">channel:</code> the name of the channel to send a response</li>

--- a/conf/evolutions/default/36.sql
+++ b/conf/evolutions/default/36.sql
@@ -1,0 +1,13 @@
+# --- !Ups
+
+DELETE FROM api_tokens;
+
+ALTER TABLE api_tokens DROP COLUMN team_id;
+ALTER TABLE api_tokens ADD COLUMN user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE;
+
+# --- !Downs
+
+DELETE FROM api_tokens;
+
+ALTER TABLE api_tokens ADD COLUMN team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE;
+ALTER TABLE api_tokens DROP COLUMN user_id;


### PR DESCRIPTION
- includes a migration that deletes existing API tokens, so we'll need to regenerate any ones we're using (there aren't many)
