### PR TITLE
Get rid of some warnings showing up during builds:

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val root =
 
 pipelineStages := Seq(rjs, digest, gzip)
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 lazy val slackClientVersion = "ce95e8ee647c87cc15314190078f02f41f72a3a6"
 lazy val slackClientProject = ProjectRef(uri(s"https://github.com/ellipsis-ai/slack-scala-client.git#$slackClientVersion"), "slack-scala-client")

--- a/test/support/DBMixin.scala
+++ b/test/support/DBMixin.scala
@@ -19,7 +19,7 @@ trait DBMixin {
       driver = config.getString("db.default.driver"),
       url = config.getString("db.default.url"),
       config = Map(
-        "user" -> config.getString("db.default.username"),
+        "username" -> config.getString("db.default.username"),
         "password" -> config.getString("db.default.password")
       )
     ) { database =>


### PR DESCRIPTION
- since we were getting bumped to scala 11.8 anyway, specify it
- stop hardcoding deprecated db 'user' in test setup
