### PR TITLE
Added first tests for APIAccessController

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -50,7 +50,7 @@ class ApplicationController @Inject() (
           Ok(views.html.index(teamAccess, versionData))
         })
       }.getOrElse {
-        reAuthFor(request, maybeTeamId)
+        DBIO.from(reAuthFor(request, maybeTeamId))
       }
     } yield result
 
@@ -89,7 +89,7 @@ class ApplicationController @Inject() (
             )
           )
         }).getOrElse {
-        reAuthFor(request, maybeTeamId)
+        DBIO.from(reAuthFor(request, maybeTeamId))
       }
     } yield result
 
@@ -117,7 +117,7 @@ class ApplicationController @Inject() (
             )
           )
         }).getOrElse {
-        reAuthFor(request, maybeTeamId)
+        DBIO.from(reAuthFor(request, maybeTeamId))
       }
     } yield result
 

--- a/app/controllers/BehaviorEditorController.scala
+++ b/app/controllers/BehaviorEditorController.scala
@@ -70,7 +70,7 @@ class BehaviorEditorController @Inject() (
           notificationsJson = Json.toJson(Array[String]()).toString
         )))
       }).getOrElse {
-        reAuthFor(request, maybeTeamId)
+        DBIO.from(reAuthFor(request, maybeTeamId))
       }
     } yield result
 
@@ -111,7 +111,7 @@ class BehaviorEditorController @Inject() (
             Some("The behavior you are trying to access could not be found."),
             Some(reAuthLinkFor(request, None))
           ))
-        withAuthDiscarded(request, response)
+        DBIO.from(withAuthDiscarded(request, response))
       }
     } yield result
 

--- a/app/controllers/ReAuthable.scala
+++ b/app/controllers/ReAuthable.scala
@@ -19,7 +19,7 @@ trait ReAuthable extends EllipsisController {
   }
 
   protected def withAuthDiscarded(request: SecuredRequest[EllipsisEnv, AnyContent], result: Result)(implicit r: RequestHeader) = {
-    DBIO.from(silhouette.env.authenticatorService.discard(request.authenticator, result))
+    silhouette.env.authenticatorService.discard(request.authenticator, result)
   }
 
   protected def reAuthFor(request: SecuredRequest[EllipsisEnv, AnyContent], maybeTeamId: Option[String])(implicit r: RequestHeader) = {

--- a/test/controllers/APIAccessControllerSpec.scala
+++ b/test/controllers/APIAccessControllerSpec.scala
@@ -1,0 +1,93 @@
+package controllers
+
+import com.mohiva.play.silhouette.test._
+import models.IDs
+import models.accounts.OAuth2Api
+import models.accounts.logintoken.LoginToken
+import models.accounts.oauth2application.OAuth2Application
+import models.accounts.user.User
+import models.team.Team
+import org.joda.time.DateTime
+import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito._
+import org.scalatestplus.play.PlaySpec
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import support.ControllerTestContextWithLoggedInUser
+
+import scala.concurrent.Future
+
+class APIAccessControllerSpec extends PlaySpec with MockitoSugar {
+
+  def newLoginTokenFor(user: User, isUsed: Boolean = false): LoginToken = LoginToken(IDs.next, user.id, isUsed, DateTime.now)
+
+  "APIAccessController.linkCustomOAuth2Service" should {
+
+    "404 if the OAuth2 application doesn't exist" in new ControllerTestContextWithLoggedInUser {
+      running(app) {
+        val appId = IDs.next
+        when(dataService.oauth2Applications.find(appId)).thenReturn(Future.successful(None))
+        val request =
+          FakeRequest(controllers.routes.APIAccessController.linkCustomOAuth2Service(appId, None, None, None)).
+            withAuthenticator(user.loginInfo)
+        val result = route(app, request).get
+        status(result) mustBe NOT_FOUND
+      }
+    }
+
+    "Log user out and redirect to signin if not logged into the right team" in new TestContext {
+      running(app) {
+        val someOtherTeam = Team(IDs.next, "")
+        val oauth2AppForOtherTeam = OAuth2Application(IDs.next, "", oauth2Api, IDs.next, IDs.next, None, someOtherTeam.id)
+        when(dataService.oauth2Applications.find(oauth2AppForOtherTeam.id)).thenReturn(Future.successful(Some(oauth2AppForOtherTeam)))
+        when(dataService.teams.find(someOtherTeam.id, user)).thenReturn(Future.successful(None))
+        val request =
+          FakeRequest(controllers.routes.APIAccessController.linkCustomOAuth2Service(oauth2AppForOtherTeam.id, None, None, None)).
+            withAuthenticator(user.loginInfo)
+        val result = route(app, request).get
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result) mustBe
+          Some(
+            routes.SocialAuthController.authenticateSlack(
+              Some(request.uri),
+              Some(someOtherTeam.id),
+              None
+            ).url
+          )
+        assertJustLoggedOut(app, result)
+        verify(dataService.oauth2Applications, times(1)).find(oauth2AppForOtherTeam.id)
+      }
+    }
+
+    "Redirect to authorization URL if logged into the right team but on first step of OAuth dance" in new TestContext {
+      running(app) {
+        when(dataService.oauth2Applications.find(oauth2App.id)).thenReturn(Future.successful(Some(oauth2App)))
+        when(dataService.teams.find(teamId, user)).thenReturn(Future.successful(Some(team)))
+        implicit val request =
+          FakeRequest(controllers.routes.APIAccessController.linkCustomOAuth2Service(oauth2App.id, None, None, None)).
+            withAuthenticator(user.loginInfo)
+        val result = route(app, request).get
+        status(result) mustBe SEE_OTHER
+        val expectedRedirectParam = routes.APIAccessController.linkCustomOAuth2Service(oauth2App.id, None, None, None).absoluteURL(secure = true)
+        redirectLocation(result).map { redirectLocation =>
+          redirectLocation must startWith(oauth2App.authorizationUrl)
+        }.getOrElse {
+          assert(false, "Redirect location must contain authorization URL")
+        }
+        verify(dataService.oauth2Applications, times(1)).find(oauth2App.id)
+      }
+    }
+
+  }
+
+  trait TestContext extends ControllerTestContextWithLoggedInUser {
+
+    lazy val authorizationUrl = "https://authorize.me/oauth2/authorize"
+    lazy val oauth2ApiId = IDs.next
+    lazy val oauth2Api = OAuth2Api(oauth2ApiId, "", authorizationUrl, "", None, None, None)
+    lazy val oauth2AppId = IDs.next
+    lazy val oauth2App = OAuth2Application(oauth2AppId, "", oauth2Api, IDs.next, IDs.next, None, teamId)
+
+  }
+
+}

--- a/test/support/ControllerTestContext.scala
+++ b/test/support/ControllerTestContext.scala
@@ -44,6 +44,13 @@ trait ControllerTestContext extends MustMatchers {
     cookies(result).get(authenticatorCookieName) mustBe None
   }
 
+  def assertJustLoggedOut(app: Application, result: Future[Result]): Unit = {
+    val authenticatorCookieName = app.configuration.getString("silhouette.authenticator.cookieName").get
+    cookies(result).get(authenticatorCookieName).map { cookie =>
+      cookie.value must have length(0)
+    }.getOrElse(assert(false, "Authenticator cookie must be present and empty"))
+  }
+
   def newUserFor(teamId: String): User = User(IDs.next, teamId, None)
 
   def newAppFor(testSilhouetteModule: TestSilhouetteModule): Application = {


### PR DESCRIPTION
- fixed the behavior when trying to use a nonexistent oauth2 app ID to 404 rather than continually asking the user to log in
