### PR TITLE
Improve error responses:

### DIFF
--- a/app/models/bots/BehaviorVersion.scala
+++ b/app/models/bots/BehaviorVersion.scala
@@ -71,11 +71,10 @@ case class BehaviorVersion(
     }.getOrElse(false)
   }
 
-  def editLinkFor(configuration: Configuration): Option[String] = {
-    configuration.getString("application.apiBaseUrl").map { baseUrl =>
-      val path = controllers.routes.BehaviorEditorController.edit(behavior.id)
-      s"$baseUrl$path"
-    }
+  def editLinkFor(configuration: Configuration): String = {
+    val baseUrl = configuration.getString("application.apiBaseUrl").get
+    val path = controllers.routes.BehaviorEditorController.edit(behavior.id)
+    s"$baseUrl$path"
   }
 
   def description: String = maybeDescription.getOrElse("")
@@ -155,7 +154,12 @@ case class BehaviorVersion(
     }.isDefined
   }
 
-  def resultFor(payload: ByteBuffer, logResult: AWSLambdaLogResult, parametersWithValues: Seq[ParameterWithValue]): BehaviorResult = {
+  def resultFor(
+                 payload: ByteBuffer,
+                 logResult: AWSLambdaLogResult,
+                 parametersWithValues: Seq[ParameterWithValue],
+                 configuration: Configuration
+               ): BehaviorResult = {
     val bytes = payload.array
     val jsonString = new java.lang.String( bytes, Charset.forName("UTF-8") )
     val json = Json.parse(jsonString)
@@ -167,13 +171,13 @@ case class BehaviorVersion(
         NoResponseResult(logResultOption)
       } else {
         if (isUnhandledError(json)) {
-          UnhandledErrorResult(logResultOption)
+          UnhandledErrorResult(this, configuration, logResultOption)
         } else if (json.toString == "null") {
-          new NoCallbackTriggeredResult()
+          NoCallbackTriggeredResult(this, configuration)
         } else if (isSyntaxError(json)) {
-          SyntaxErrorResult(json, logResultOption)
+          SyntaxErrorResult(this, configuration, json, logResultOption)
         } else {
-          HandledErrorResult(json, logResultOption)
+          HandledErrorResult(this, configuration, json, logResultOption)
         }
       }
     }
@@ -350,7 +354,7 @@ object BehaviorVersionQueries {
 
   import services.AWSLambdaConstants._
 
-  def withoutBuiltin(params: Array[String]) = params.filterNot(ea => ea == ON_SUCCESS_PARAM || ea == ON_ERROR_PARAM || ea == CONTEXT_PARAM)
+  def withoutBuiltin(params: Array[String]) = params.filterNot(ea => ea == CONTEXT_PARAM)
 
   val functionBodyRegex = """(?s)^\s*function\s*\([^\)]*\)\s*\{(.*)\}$""".r
 

--- a/app/models/bots/builtins/DisplayHelpBehavior.scala
+++ b/app/models/bots/builtins/DisplayHelpBehavior.scala
@@ -46,10 +46,8 @@ case class DisplayHelpBehavior(
             s""
 
         val triggersString = namedTriggers + regexTriggerString
-        val editLink = behavior.editLinkFor(lambdaService.configuration).map { link =>
-          s"[Details]($link)"
-        }.getOrElse("")
-        s"\n- $triggersString $editLink"
+        val link = behavior.editLinkFor(lambdaService.configuration)
+        s"\n- $triggersString [Details]($link)"
       }
       if (behaviorStrings.isEmpty) {
         ""

--- a/app/models/bots/builtins/RememberBehavior.scala
+++ b/app/models/bots/builtins/RememberBehavior.scala
@@ -35,10 +35,9 @@ case class RememberBehavior(messageContext: MessageContext, lambdaService: AWSLa
         }.map(Some(_)) transactionally
       }.getOrElse(DBIO.successful(None))
     } yield {
-      maybeBehaviorVersion.flatMap { behaviorVersion =>
-        behaviorVersion.editLinkFor(lambdaService.configuration).map { link =>
-          SimpleTextResult(s"OK, I compiled recent messages at $link")
-        }
+      maybeBehaviorVersion.map { behaviorVersion =>
+        val link = behaviorVersion.editLinkFor(lambdaService.configuration)
+        SimpleTextResult(s"OK, I compiled recent messages into [a new behavior]($link)")
       }.getOrElse{
         NoResponseResult(None)
       }

--- a/app/services/AWSLambdaConstants.scala
+++ b/app/services/AWSLambdaConstants.scala
@@ -2,10 +2,9 @@ package services
 
 object AWSLambdaConstants {
   val NO_RESPONSE_KEY = "noResponse"
-  val ON_SUCCESS_PARAM = "onSuccess"
-  val ON_ERROR_PARAM = "onError"
   val CONTEXT_PARAM = "ellipsis"
-  val HANDLER_PARAMS = Array(ON_SUCCESS_PARAM, ON_ERROR_PARAM)
+  val SUCCESS_CALLBACK = s"$CONTEXT_PARAM.success()"
+  val ERROR_CALLBACK = s"$CONTEXT_PARAM.error()"
   val INVOCATION_TIMEOUT_SECONDS = 10
   val TOKEN_KEY = "token"
   val USER_INFO_KEY = "userInfo"

--- a/app/services/AWSLambdaLogResult.scala
+++ b/app/services/AWSLambdaLogResult.scala
@@ -20,6 +20,11 @@ object AWSLambdaLogResult {
       m.subgroups.headOption
     }.getOrElse(text)
     var maybeErrorContent: Option[String] = None
+    val syntaxErrorRegex = """(?s)(.*\n)(Syntax error in module 'index': SyntaxError.*)\n[^\n]*\nEND.*""".r
+    syntaxErrorRegex.findFirstMatchIn(text).foreach { m =>
+      nonErrorContent = m.subgroups.head
+      maybeErrorContent = None
+    }
     val extractErrorRegex = """(?s)(.*\n)\S+\t\S+\t(\S*Error:.*)\n[^\n]*\nEND.*""".r
     extractErrorRegex.findFirstMatchIn(text).foreach { m =>
       nonErrorContent = m.subgroups.head

--- a/app/services/AWSLambdaServiceImpl.scala
+++ b/app/services/AWSLambdaServiceImpl.scala
@@ -72,7 +72,7 @@ class AWSLambdaServiceImpl @Inject() (
       missingEnvVars <- models.run(behaviorVersion.missingEnvironmentVariablesIn(environmentVariables, dataService))
       requiredOAuth2ApiConfigs <- models.run(RequiredOAuth2ApiConfigQueries.allFor(behaviorVersion))
       result <- if (missingEnvVars.nonEmpty) {
-        Future.successful(MissingEnvVarsResult(missingEnvVars))
+        Future.successful(MissingEnvVarsResult(behaviorVersion, configuration, missingEnvVars))
       } else if (behaviorVersion.functionBody.isEmpty) {
         Future.successful(SuccessResult(JsNull, parametersWithValues, behaviorVersion.maybeResponseTemplate, None))
       } else {
@@ -106,7 +106,7 @@ class AWSLambdaServiceImpl @Inject() (
               JavaFutureWrapper.wrap(client.invokeAsync(invokeRequest)).map { result =>
                 val logString = new java.lang.String(new BASE64Decoder().decodeBuffer(result.getLogResult))
                 val logResult = AWSLambdaLogResult.fromText(logString, behaviorVersion.isInDevelopmentMode)
-                behaviorVersion.resultFor(result.getPayload, logResult, parametersWithValues)
+                behaviorVersion.resultFor(result.getPayload, logResult, parametersWithValues, configuration)
               }.recover {
                 case e: java.util.concurrent.ExecutionException => {
                   e.getMessage match {


### PR DESCRIPTION
- include a link to the offending behavior in the response
- stop having syntax errors get shown as console logs
- fix success/error callback names in error responses
