### PR TITLE
Added basic conditional construct to behavior templates

### DIFF
--- a/app/models/bots/templates/MarkdownRenderer.scala
+++ b/app/models/bots/templates/MarkdownRenderer.scala
@@ -86,4 +86,21 @@ case class MarkdownRenderer(
       }
     }
   }
+
+  def visit(conditional: Conditional): Unit = {
+    val dotString = conditional.condition.dotString
+    lookUp(Substitution(conditional.condition)) match {
+      case lookupResult: JsUndefined => stringBuilder.append(notFound(dotString))
+      case lookupResult: JsDefined => {
+        lookupResult.value match {
+          case bool: JsBoolean => {
+            if (bool.value) {
+              visit(conditional.body)
+            }
+          }
+          case nonBoolean => stringBuilder.append(s"**$dotString is not a boolean** (${nonBoolean.toString})")
+        }
+      }
+    }
+  }
 }

--- a/app/models/bots/templates/TemplateParser.scala
+++ b/app/models/bots/templates/TemplateParser.scala
@@ -8,7 +8,7 @@ class TemplateParser extends RegexParsers with JavaTokenParsers {
 
   override def skipWhitespace = false
 
-  val reserved: Parser[String] = "endfor"
+  val reserved: Parser[String] = "endfor" | "endif"
 
   def text: Parser[Text] = """[^\{]+""".r ^^ { s => Text(s) }
 
@@ -18,12 +18,16 @@ class TemplateParser extends RegexParsers with JavaTokenParsers {
 
   def substitution: Parser[Substitution] = """\{\s*""".r ~> path <~ """\s*\}""".r ^^ { path => Substitution(path) }
 
-  def block: Parser[Block] = rep(text | substitution | iteration) ^^ { children => Block(children) }
+  def block: Parser[Block] = rep(text | substitution | iteration | conditional) ^^ { children => Block(children) }
 
   def iteration: Parser[Iteration] =
     """\{\s*for\s+""".r ~> identifier ~ """\s+in\s+""".r ~ path ~ """\s*\}""".r ~ block <~ """\{\s*endfor\s*\}""".r ^^ {
     case itemIdentifier ~ _ ~ listPath ~ _ ~ block =>
       Iteration(itemIdentifier, listPath, block)
+  }
+
+  def conditional: Parser[Conditional] = """\{\s*if\s+""".r ~> path ~ """\s*\}\s*""".r ~ block <~ """\{\s*endif\s*\}""".r ^^ {
+    case condition ~ _ ~ block => Conditional(condition, block)
   }
 
   def parseBlockFrom(text: String): ParseResult[Block] = parse(block, text)

--- a/app/models/bots/templates/ast/Expr.scala
+++ b/app/models/bots/templates/ast/Expr.scala
@@ -70,3 +70,11 @@ case class Iteration(item: Identifier, list: Path, body: Block) extends Expr {
   }
 
 }
+
+case class Conditional(condition: Path, body: Block) extends Expr {
+
+  override def accept(visitor: MarkdownRenderer): Unit = {
+    visitor.visit(this)
+  }
+
+}

--- a/test/TemplateParserSpec.scala
+++ b/test/TemplateParserSpec.scala
@@ -93,6 +93,30 @@ class TemplateParserSpec extends PlaySpec {
 
     }
 
+    "parse a conditional" in {
+      val result = parse("{if foo.isBar}foo is a bar{endif}")
+      result mustBe Block(Seq(
+        Conditional(pathFor("foo", "isBar"), Block(Seq(Text("foo is a bar")))))
+      )
+    }
+
+    "parse nested conditionals" in {
+      val result = parse("{if foo.isBar}{if shouldDisplay}foo is a bar{endif}{endif}")
+      result mustBe Block(Seq(
+        Conditional(
+          pathFor("foo", "isBar"),
+          Block(Seq(
+            Conditional(
+              pathFor("shouldDisplay"),
+              Block(Seq(
+                Text("foo is a bar")
+              ))
+            )
+          ))
+        ))
+      )
+    }
+
   }
 
 }


### PR DESCRIPTION
`{if successResult.someBoolean}print something{endif}`

For now, went with the most restrictive version, where `someBoolean` must be an actual boolean or it displays an error. We can open this up somewhat later when we are sure of what we want to do
