### PR TITLE
Include regex triggers when counting how many times a param has been used

### DIFF
--- a/app/assets/javascripts/behavior_editor/user_input_configuration.jsx
+++ b/app/assets/javascripts/behavior_editor/user_input_configuration.jsx
@@ -53,12 +53,12 @@ define(function(require) {
       return this.props.userParams.length > 0;
     },
 
-    countLinkedTriggersForParamName: function(paramName) {
-      return this.props.triggers.filter((trigger) => trigger.usesParamName(paramName)).length;
+    countLinkedTriggersForParam: function(paramName, paramIndex) {
+      return this.props.triggers.filter((trigger) => trigger.usesParamName(paramName) || trigger.capturesParamIndex(paramIndex)).length;
     },
 
     hasLinkedTriggers: function() {
-      return this.props.userParams.some((param) => this.countLinkedTriggersForParamName(param.name));
+      return this.props.userParams.some((param, index) => this.countLinkedTriggersForParam(param.name, index));
     },
 
     hasRegexCapturingTriggers: function() {
@@ -132,7 +132,7 @@ define(function(require) {
                             onEnterKey={this.onEnterKey.bind(this, paramIndex)}
                             onNameFocus={this.onNameFocus.bind(this, paramIndex)}
                             onNameBlur={this.onNameBlur.bind(this, paramIndex)}
-                            numLinkedTriggers={this.countLinkedTriggersForParamName(param.name)}
+                            numLinkedTriggers={this.countLinkedTriggersForParam(param.name, paramIndex)}
                             id={paramIndex}
                           />
                         </div>

--- a/app/assets/javascripts/models/trigger.jsx
+++ b/app/assets/javascripts/models/trigger.jsx
@@ -45,6 +45,14 @@ define(function() {
       return !this.isRegex && pattern.test(this.text);
     }
 
+    capturesParamIndex(index) {
+      if (!this.isRegex) {
+        return false;
+      }
+      var matches = this.text.match(/^\(.+?\)|[^\\]\(.*?[^\\]\)/g);
+      return !!(matches && matches[index]);
+    }
+
     hasRegexCapturingParens() {
       return this.isRegex && /\(.+?\)/.test(this.text);
     }

--- a/test/trigger_spec.js
+++ b/test/trigger_spec.js
@@ -1,0 +1,31 @@
+jest.unmock("../app/assets/javascripts/models/trigger");
+
+const Trigger = require("../app/assets/javascripts/models/trigger");
+
+describe("Trigger", () => {
+  describe("capturesParamIndex", () => {
+    it("returns true for 0, false for 1+, when there’s a single capturing paren", () => {
+      var t = new Trigger({ isRegex: true, text: "add (.+)"});
+      expect(t.capturesParamIndex(0)).toBe(true);
+      expect(t.capturesParamIndex(1)).toBe(false);
+      expect(t.capturesParamIndex(2)).toBe(false);
+    });
+
+    it("returns true for 0 and 1 when there’s at least two capturing parens", () => {
+      var t = new Trigger({ isRegex: true, text: "add (.+?) plus (.+)"});
+      expect(t.capturesParamIndex(0)).toBe(true);
+      expect(t.capturesParamIndex(1)).toBe(true);
+      expect(t.capturesParamIndex(2)).toBe(false);
+    });
+
+    it("returns false when parens are preceded by backslashes", () => {
+      var t = new Trigger({ isRegex: true, text: "add \\(.+?\\)"});
+      expect(t.capturesParamIndex(0)).toBe(false);
+    });
+
+    it("returns true when capturing parens are the first thing", () => {
+      var t = new Trigger({ isRegex: true, text: "(.+?) is good"});
+      expect(t.capturesParamIndex(0)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Count a param as used when a trigger is regex and has the right number of capturing parens
