### PR TITLE
Split out data type behaviors from the rest

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -30,7 +30,7 @@ class ApplicationController @Inject() (
     for {
       teamAccess <- dataService.users.teamAccessFor(user, maybeTeamId)
       maybeBehaviors <- teamAccess.maybeTargetTeam.map { team =>
-        dataService.behaviors.allForTeam(team).map { behaviors =>
+        dataService.behaviors.visibleForTeam(team).map { behaviors =>
           Some(behaviors)
         }
       }.getOrElse {
@@ -56,7 +56,7 @@ class ApplicationController @Inject() (
   case class PublishedBehaviorInfo(published: Seq[BehaviorCategory], installedBehaviors: Seq[InstalledBehaviorData])
 
   private def withPublishedBehaviorInfoFor(team: Team): Future[PublishedBehaviorInfo] = {
-    dataService.behaviors.allForTeam(team).map { behaviors =>
+    dataService.behaviors.visibleForTeam(team).map { behaviors =>
       behaviors.map { ea => InstalledBehaviorData(ea.id, ea.maybeImportedId)}
     }.map { installedBehaviors =>
       val githubService = GithubService(team, ws, configuration, cache, dataService)

--- a/app/controllers/BehaviorBackedDataTypeController.scala
+++ b/app/controllers/BehaviorBackedDataTypeController.scala
@@ -1,0 +1,40 @@
+package controllers
+
+import javax.inject.Inject
+
+import com.mohiva.play.silhouette.api.Silhouette
+import models.silhouette.EllipsisEnv
+import play.api.i18n.MessagesApi
+import services.DataService
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class BehaviorBackedDataTypeController @Inject() (
+                                                  val messagesApi: MessagesApi,
+                                                  val silhouette: Silhouette[EllipsisEnv],
+                                                  val dataService: DataService
+                                                ) extends ReAuthable {
+
+  def list(maybeTeamId: Option[String]) = silhouette.SecuredAction.async { implicit request =>
+    val user = request.identity
+    for {
+      teamAccess <- dataService.users.teamAccessFor(user, maybeTeamId)
+      dataTypes <- teamAccess.maybeTargetTeam.map { team =>
+        dataService.behaviorBackedDataTypes.allFor(team)
+      }.getOrElse(Future.successful(Seq()))
+    } yield {
+      teamAccess.maybeTargetTeam.map { team =>
+        Ok(
+          views.html.behaviorBackedDataTypeList(
+            teamAccess,
+            dataTypes
+          )
+        )
+      }.getOrElse{
+        NotFound("Team not accessible")
+      }
+    }
+  }
+
+}

--- a/app/models/behaviors/behavior/BehaviorService.scala
+++ b/app/models/behaviors/behavior/BehaviorService.scala
@@ -14,6 +14,8 @@ trait BehaviorService {
 
   def allForTeam(team: Team): Future[Seq[Behavior]]
 
+  def visibleForTeam(team: Team): Future[Seq[Behavior]]
+
   def createFor(team: Team, maybeImportedId: Option[String]): Future[Behavior]
 
   def delete(behavior: Behavior): Future[Behavior]

--- a/app/models/behaviors/behavior/BehaviorServiceImpl.scala
+++ b/app/models/behaviors/behavior/BehaviorServiceImpl.scala
@@ -70,6 +70,16 @@ class BehaviorServiceImpl @Inject() (
     dataService.run(action)
   }
 
+  def visibleForTeam(team: Team): Future[Seq[Behavior]] = {
+    for {
+      all <- allForTeam(team)
+      dataTypes <- dataService.behaviorBackedDataTypes.allFor(team)
+    } yield {
+      val invisible = dataTypes.map(_.behavior)
+      all.diff(invisible)
+    }
+  }
+
   def createFor(team: Team, maybeImportedId: Option[String]): Future[Behavior] = {
     val raw = RawBehavior(IDs.next, team.id, None, maybeImportedId, DateTime.now)
 

--- a/app/views/behaviorBackedDataTypeList.scala.html
+++ b/app/views/behaviorBackedDataTypeList.scala.html
@@ -1,0 +1,23 @@
+@(
+  teamAccess: models.accounts.user.UserTeamAccess,
+  dataTypes: Seq[models.behaviors.behaviorparameter.BehaviorBackedDataType]
+)(implicit messages: Messages, r: RequestHeader)
+
+@main("Data types", Some(teamAccess)) {
+  <div id="content" class="content">
+    <div class="bg-blue-medium pvxxl border-emphasis-bottom border-blue bg-large-logo">
+      <div class="container">
+        <p class="type-l type-white">
+          Data types
+        </p>
+      </div>
+    </div>
+    <ul>
+    @dataTypes.map { ea =>
+      <li>
+        <a href="@routes.BehaviorEditorController.edit(ea.behavior.id)">@ea.name</a>
+      </li>
+    }
+    </ul>
+  </div>
+}

--- a/conf/routes
+++ b/conf/routes
@@ -18,6 +18,7 @@ POST        /clone_behavior                           @controllers.BehaviorEdito
 GET         /regex_validation_errors/:pattern         @controllers.BehaviorEditorController.regexValidationErrorsFor(pattern: String)
 GET         /version_info/:behaviorId                 @controllers.BehaviorEditorController.versionInfoFor(behaviorId: String)
 POST        /test_behavior_version                    @controllers.BehaviorEditorController.test
+GET         /data_types                               @controllers.BehaviorBackedDataTypeController.list(teamId: Option[String] ?= None)
 
 POST        /submit_environment_variables             @controllers.EnvironmentVariablesController.submit
 POST        /delete_environment_variable              @controllers.EnvironmentVariablesController.delete


### PR DESCRIPTION
- don't show them in main behavior list
- added new unlinked /data_types endpoint to get to them
