### PR TITLE
make sure newly added param types have the right format

### DIFF
--- a/app/assets/javascripts/behavior_editor/index.jsx
+++ b/app/assets/javascripts/behavior_editor/index.jsx
@@ -492,7 +492,7 @@ return React.createClass({
     return Object.assign({
       name: '',
       question: '',
-      paramType: { name: 'Text' }
+      paramType: this.props.paramTypes[0]
     }, optionalValues);
   },
 


### PR DESCRIPTION
- instead of hardcoding this, just grab the first type from the paramTypes list. this should be less fragile
