### PR TITLE
Fix missing image in CSS

### DIFF
--- a/app/assets/stylesheets/bg.less
+++ b/app/assets/stylesheets/bg.less
@@ -56,7 +56,7 @@
   background-color: @pink-dark;
 }
 
-@bg_logo_url: url(/assets/images/bg_logo.png);
+@bg_logo_url: url(../images/bg_logo.png);
 .bg-large-logo {
   background-image: @bg_logo_url, @bg_logo_url, @bg_logo_url, @bg_logo_url;
   background-size: 800px 500px;


### PR DESCRIPTION
Use a relative path for an image specified in CSS, so that it doesn't matter whether it's /assets/ or //assets.ellipsis.ai/
