### PR TITLE
Fix bug that broke naming newly created user params/inputs

### DIFF
--- a/app/assets/javascripts/behavior_editor/index.jsx
+++ b/app/assets/javascripts/behavior_editor/index.jsx
@@ -505,7 +505,7 @@ return React.createClass({
   /* Setters/togglers */
 
   createNewParam: function(optionalValues) {
-    return new Param({ paramType: this.props.paramTypes[0] }, optionalValues);
+    return new Param(Object.assign({ paramType: this.props.paramTypes[0] }, optionalValues));
   },
 
   addParam: function() {

--- a/test/behavior_editor_spec.js
+++ b/test/behavior_editor_spec.js
@@ -357,4 +357,19 @@ describe('BehaviorEditor', () => {
       expect(editor.renderNormalBehavior).not.toBeCalled();
     });
   });
+
+  describe('createNewParam', () => {
+    it("creates a new parameter with the parameter type set to the first possible one", () => {
+      let editor = createEditor(editorConfig);
+      let newParam = editor.createNewParam();
+      expect(newParam.paramType).toEqual(editorConfig.paramTypes[0]);
+    });
+
+    it("creates a new parameter with other attributes as desired", () => {
+      let editor = createEditor(editorConfig);
+      let newParam = editor.createNewParam({ name: "clownCar", question: "how did twitter propel itself?" });
+      expect(newParam.name).toEqual("clownCar");
+      expect(newParam.question).toEqual("how did twitter propel itself?");
+    });
+  });
 });


### PR DESCRIPTION
Fixed a bug where createNewParam wasn't setting properties of new params properly.

Added a test that would've caught the bug. :/
