### PR TITLE
Try to speed up behavior saves:

### DIFF
--- a/app/models/behaviors/behaviorversion/BehaviorVersionService.scala
+++ b/app/models/behaviors/behaviorversion/BehaviorVersionService.scala
@@ -40,6 +40,8 @@ trait BehaviorVersionService {
 
   def maybeFunctionFor(behaviorVersion: BehaviorVersion): Future[Option[String]]
 
+  def maybePreviousFor(behaviorVersion: BehaviorVersion): Future[Option[BehaviorVersion]]
+
   def resultFor(
                  behaviorVersion: BehaviorVersion,
                  parametersWithValues: Seq[ParameterWithValue],

--- a/app/models/behaviors/behaviorversion/BehaviorVersionServiceImpl.scala
+++ b/app/models/behaviors/behaviorversion/BehaviorVersionServiceImpl.scala
@@ -238,6 +238,17 @@ class BehaviorVersionServiceImpl @Inject() (
     }.getOrElse(Future.successful(None))
   }
 
+  def maybePreviousFor(behaviorVersion: BehaviorVersion): Future[Option[BehaviorVersion]] = {
+    allFor(behaviorVersion.behavior).map { versions =>
+      val index = versions.indexWhere(_.id == behaviorVersion.id)
+      if (index == versions.size - 1) {
+        None
+      } else {
+        Some(versions(index + 1))
+      }
+    }
+  }
+
   def resultFor(
                  behaviorVersion: BehaviorVersion,
                  parametersWithValues: Seq[ParameterWithValue],


### PR DESCRIPTION
If required npm modules haven't changed since last version and are available on disk, copy them over rather than reinstalling
- Once we are running on multiple instances, we'll want to look somewhere other than the local hard drive, but this should help for now
