### PR TITLE
Update URL after saving a new behavior

### DIFF
--- a/app/assets/javascripts/behavior_editor/index.jsx
+++ b/app/assets/javascripts/behavior_editor/index.jsx
@@ -1245,6 +1245,9 @@ return React.createClass({
     if (nextProps.onLoad) {
       nextProps.onLoad();
     }
+    if (newBehaviorVersion.behaviorId) {
+      BrowserUtils.replaceURL(jsRoutes.controllers.BehaviorEditorController.edit(newBehaviorVersion.behaviorId).url);
+    }
   },
 
   renderPageHeading: function() {

--- a/app/views/editBehavior.scala.html
+++ b/app/views/editBehavior.scala.html
@@ -8,6 +8,7 @@
 
 @main("Edit behavior", Some(data.teamAccess)) {
   @helper.javascriptRouter("jsRoutes")(
+    routes.javascript.BehaviorEditorController.edit,
     routes.javascript.BehaviorEditorController.save,
     routes.javascript.BehaviorEditorController.regexValidationErrorsFor,
     routes.javascript.BehaviorEditorController.versionInfoFor,


### PR DESCRIPTION
When reloading the behavior editor after save, update the URL to use the edit route, even if we started with the new behavior route.
