### PR TITLE
Fix restoring versions and submitting the behavior editor form without ajax

### DIFF
--- a/app/controllers/BehaviorEditorController.scala
+++ b/app/controllers/BehaviorEditorController.scala
@@ -141,10 +141,11 @@ class BehaviorEditorController @Inject() (
               } yield {
                 if (info.maybeRedirect.contains("newOAuth2Application")) {
                   Redirect(routes.OAuth2ApplicationController.newApp(maybeRequiredOAuth2ApiConfig.map(_.id), Some(data.teamId), Some(behavior.id)))
-                } else if (request.accepts("application/json")) {
-                  Ok(Json.toJson(behaviorVersionData))
                 } else {
-                  Redirect(routes.BehaviorEditorController.edit(behavior.id, justSaved = Some(true)))
+                  render {
+                    case Accepts.Html() => Redirect(routes.BehaviorEditorController.edit(behavior.id, justSaved = Some(true)))
+                    case Accepts.Json() => Ok(Json.toJson(behaviorVersionData))
+                  }
                 }
               }).getOrElse {
                 NotFound(


### PR DESCRIPTION
Use render { case… } approach for delivering the edit behavior response from the controller:

fixes my clumsy attempt to return HTML when submitting the form normally instead of via
ajax.

Resolves #795 
