### PR TITLE
Overflow/scrolling fixes

### DIFF
--- a/app/assets/javascripts/behavior_editor/trigger_input.jsx
+++ b/app/assets/javascripts/behavior_editor/trigger_input.jsx
@@ -199,7 +199,9 @@ return React.createClass({
         <div className="prl">
           <b>This regex pattern has an error:</b>
         </div>
-        <pre>{this.state.regexError || "\n\n\n"}</pre>
+        <div className="display-overflow-scroll">
+          <pre>{this.state.regexError || "\n\n\n"}</pre>
+        </div>
         <div>{this.getHelpForRegexError()}</div>
       </div>
     );

--- a/app/assets/stylesheets/display.less
+++ b/app/assets/stylesheets/display.less
@@ -33,7 +33,13 @@
 
 .display-limit-width {
   display: block;
-  width: 100%;
-  max-width: 100%;
+  width: 0;
+  min-width: 100%;
   box-sizing: border-box;
+}
+
+.display-overflow-scroll {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
 }


### PR DESCRIPTION
Fix the way display-limit-width works, so that it prevents tables from overflowing.

Add a new class for preventing regex error messages from overflowing their container/
