### PR TITLE
Added an optional `branch` query param for pages where you install published behaviors

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -4,8 +4,8 @@
 
 # An example controller showing a sample home page
 GET         /                                         @controllers.ApplicationController.index(teamId: Option[String] ?= None)
-GET         /intro                                    @controllers.ApplicationController.intro(teamId: Option[String] ?= None)
-GET         /install_behaviors                        @controllers.ApplicationController.installBehaviors(teamId: Option[String] ?= None)
+GET         /intro                                    @controllers.ApplicationController.intro(teamId: Option[String] ?= None, branch: Option[String] ?= None)
+GET         /install_behaviors                        @controllers.ApplicationController.installBehaviors(teamId: Option[String] ?= None, branch: Option[String] ?= None)
 GET         /new_behavior                             @controllers.BehaviorEditorController.newForNormalBehavior(teamId: Option[String] ?= None)
 GET         /new_data_type                            @controllers.BehaviorEditorController.newForDataType(teamId: Option[String] ?= None)
 GET         /edit_behavior/:id                        @controllers.BehaviorEditorController.edit(id: String, justSaved: Option[Boolean] ?= None)


### PR DESCRIPTION
- specifying this let's you try against non-master branches for behaviors repo, to make sure things work
- if `branch` param is included, cache is bypassed
