### PR TITLE
Fix whether the callback URL is displayed on the oauth2 application

### DIFF
--- a/app/assets/javascripts/application_editor/index.jsx
+++ b/app/assets/javascripts/application_editor/index.jsx
@@ -135,6 +135,10 @@ define(function(require) {
       return this.state.shouldRevealApplicationUrl;
     },
 
+    shouldRevealCallbackUrl: function() {
+      return this.props.requiresAuth || !!(this.state.applicationApi && this.state.applicationApi.requiresAuth);
+    },
+
     getApplicationClientId: function() {
       return this.state.applicationClientId;
     },
@@ -324,7 +328,7 @@ define(function(require) {
     },
 
     renderCallbackUrl: function() {
-      if (this.props.requiresAuth) {
+      if (this.shouldRevealCallbackUrl()) {
         return (
           <li>
             <div>Copy and paste this for the <b>callback URL</b> (sometimes called <b>redirect URL</b>):</div>


### PR DESCRIPTION
Fallback to the currently selected API to determine whether an oauth2 application requires auth and therefore should display the callback URL.
