### PR TITLE
Disable author name data service call while we figure out why it breaks

### DIFF
--- a/app/models/behaviors/builtins/DisplayHelpBehavior.scala
+++ b/app/models/behaviors/builtins/DisplayHelpBehavior.scala
@@ -27,7 +27,8 @@ case class DisplayHelpBehavior(
     for {
       triggers <- dataService.messageTriggers.allFor(behaviorVersion)
       authorNames <- messageContext match {
-        case c: SlackMessageContext => dataService.behaviors.authorNamesFor(behaviorVersion.behavior, c)
+        // TODO: this is broken in production for some teams
+//        case c: SlackMessageContext => dataService.behaviors.authorNamesFor(behaviorVersion.behavior, c)
         case _ => Future.successful(Seq())
       }
     } yield {


### PR DESCRIPTION
the built-in help