### PR TITLE
Handle formatted links in data type params

### DIFF
--- a/app/models/behaviors/behaviorparameter/BehaviorParameterType.scala
+++ b/app/models/behaviors/behaviorparameter/BehaviorParameterType.scala
@@ -146,7 +146,7 @@ case class BehaviorBackedDataType(behavior: Behavior) extends BehaviorParameterT
   private def cachedValidValueForLabel(text: String, context: BehaviorParameterContext): Option[ValidValue] = {
     for {
       values <- cachedValuesFor(context)
-      value <- values.find((ea) => textMatchesLabel(text, ea.label))
+      value <- values.find((ea) => textMatchesLabel(text, ea.label, context))
     } yield value
   }
 
@@ -210,17 +210,17 @@ case class BehaviorBackedDataType(behavior: Behavior) extends BehaviorParameterT
     }
   }
 
-  private def textMatchesLabel(text: String, label: String): Boolean = {
+  private def textMatchesLabel(text: String, label: String, context: BehaviorParameterContext): Boolean = {
     val lowercaseText = text.toLowerCase
-    val insideOfFormattedLink = text.replaceFirst("""^<.+\|(.+)>$""", "$1").toLowerCase
+    val unformattedText = context.event.context.unformatTextFragment(text).toLowerCase
     val lowercaseLabel = label.toLowerCase
-    lowercaseLabel == lowercaseText || lowercaseLabel == insideOfFormattedLink
+    lowercaseLabel == lowercaseText || lowercaseLabel == unformattedText
   }
 
   private def fetchMatchFor(text: String, context: BehaviorParameterContext): Future[Option[ValidValue]] = {
     fetchValidValues(context).map { validValues =>
       validValues.find {
-        v => v.id == text || textMatchesLabel(text, v.label)
+        v => v.id == text || textMatchesLabel(text, v.label, context)
       }
     }
   }

--- a/app/models/behaviors/events/Context.scala
+++ b/app/models/behaviors/events/Context.scala
@@ -16,4 +16,10 @@ trait Context {
 
   def maybeOngoingConversation(dataService: DataService): Future[Option[Conversation]]
 
+  def unformatTextFragment(text: String): String = {
+    // Override for client-specific code to strip formatting from text
+    text
+  }
+
+
 }

--- a/app/models/behaviors/events/SlackMessageContext.scala
+++ b/app/models/behaviors/events/SlackMessageContext.scala
@@ -161,6 +161,11 @@ case class SlackMessageContext(
       )
     }
   }
+
+  override def unformatTextFragment(text: String): String = {
+    // Replace formatted links with their visible text
+    text.replaceAll("""<.+?\|(.+?)>""", "$1")
+  }
 }
 
 object SlackMessageContext {


### PR DESCRIPTION
Use the message context to unformat a text fragment in case it has client-specific formatting (e.g. slack turning url fragments and email addresses into formatted links), and then check if that matches a particular data-type label.

Fixes a bug where, e.g. the message containing `<mailto:luke@ellipsis.ai|luke@ellipsis.ai>` doesn't match a data-type label `luke@ellipsis.ai`.