### PR TITLE
Also populate legacy "oauthToken" key when invoking behaviors

### DIFF
--- a/app/models/behaviors/UserInfo.scala
+++ b/app/models/behaviors/UserInfo.scala
@@ -16,7 +16,8 @@ case class LinkedInfo(externalSystem: String, accessToken: String) {
   def toJson: JsObject = {
     JsObject(Seq(
       "externalSystem" -> JsString(externalSystem),
-      "token" -> JsString(accessToken)
+      "token" -> JsString(accessToken),
+      "oauthToken" -> JsString(accessToken)
     ))
   }
 


### PR DESCRIPTION
- this will make existing behaviors work without being redeployed to lambda