### PR TITLE
Ensure error messages are formatted as multi-line code blocks for Slack.

### DIFF
--- a/app/models/behaviors/BotResult.scala
+++ b/app/models/behaviors/BotResult.scala
@@ -132,7 +132,7 @@ case class HandledErrorResult(
 
   def text: String = {
     val detail = (json \ "errorMessage").toOption.map(processedResultFor).map { msg =>
-      s":\n\n```$msg```"
+      s":\n\n```\n$msg\n```"
     }.getOrElse("")
     s"I encountered an error in ${linkToBehaviorFor("one of your skills")}$detail"
   }


### PR DESCRIPTION
Turns out ``` code blocks need new lines surrounding the block.