### PR TITLE
Fix React warning by avoiding duplicate environment variable names

### DIFF
--- a/app/json/BehaviorEditorData.scala
+++ b/app/json/BehaviorEditorData.scala
@@ -105,12 +105,10 @@ object BehaviorEditorData {
           dataService
         )
       }
-      val uniqEnvironmentVariables = teamEnvironmentVariables ++
-        userEnvironmentVariables.filter(uev => !teamEnvironmentVariables.exists(tev => tev.name == uev.name))
       BehaviorEditorData(
         teamAccess,
         versionData,
-        uniqEnvironmentVariables.map(EnvironmentVariableData.withoutValueFor),
+        teamEnvironmentVariables.map(EnvironmentVariableData.withoutValueFor),
         paramTypeData,
         oAuth2Applications.map(OAuth2ApplicationData.from),
         oauth2Apis.map(OAuth2ApiData.from),


### PR DESCRIPTION
Remove user environment variables with the same name as any team environment variables.

Not sure if this is an ideal approach, but it depends a bit on how we think we'll distinguish these in the UI, at all.