### PR TITLE
Stop modifying behaviors through opening the versions panel

### DIFF
--- a/app/assets/javascripts/behavior_editor/index.jsx
+++ b/app/assets/javascripts/behavior_editor/index.jsx
@@ -771,13 +771,13 @@ return React.createClass({
 
   showVersionIndex: function(versionIndex, optionalCallback) {
     var version = this.getVersions()[versionIndex];
-    var newBehavior = Object.assign({}, version, {
+    var newBehaviorProps = Object.assign({}, version, {
       groupId: this.props.groupId,
       teamId: this.props.teamId,
       behaviorId: this.props.behaviorId
     });
     this.setState({
-      behavior: this.getBehaviorFromProps(newBehavior),
+      behavior: this.getBehaviorFromProps(newBehaviorProps),
       revealCodeEditor: !!version.functionBody,
       justSaved: false
     }, optionalCallback);


### PR DESCRIPTION
Turns out we were dropping the `description` property whenever switching versions of a behavior, and canceling the versions panel still switches versions (to the most recent version).