### PR TITLE
Use the configured skill name for published skills

### DIFF
--- a/app/services/GithubService.scala
+++ b/app/services/GithubService.scala
@@ -152,8 +152,8 @@ case class GithubService(team: Team, ws: WSClient, config: Configuration, cache:
           } yield {
             val githubUrl = githubUrlForGroupPath(groupPath)
             val maybePublishedId = maybeConfig.map(_.publishedId)
-            val name = maybeConfig.map(_.name)
-            BehaviorGroupData(None, name.getOrElse(groupPath), readme, behaviors, Some(githubUrl), None, maybePublishedId, DateTime.now)
+            val name = maybeConfig.map(_.name).getOrElse(groupPath)
+            BehaviorGroupData(None, name, readme, behaviors, Some(githubUrl), None, maybePublishedId, DateTime.now)
           }).map(Some(_))
         }).getOrElse(Future.successful(None))
     }


### PR DESCRIPTION
Use the actual skill name if there is one for gathering published skills, and fallback to the folder name only when there isn't a configured name