### PR TITLE
Keep param values around more reliably when testing skills

### DIFF
--- a/app/assets/javascripts/behavior_editor/behavior_tester.jsx
+++ b/app/assets/javascripts/behavior_editor/behavior_tester.jsx
@@ -51,7 +51,10 @@ define(function(require) {
           triggerErrorOccurred: false
         });
       }
-      if (JSON.stringify(this.props.params) !== JSON.stringify(newProps.params)) {
+      if (this.props.params.some((param, index) => {
+        return !newProps.params[index] ||
+          !param.isSameNameAndTypeAs(newProps.params[index]);
+      })) {
         this.setState({
           paramValues: {}
         });

--- a/app/assets/javascripts/models/param.jsx
+++ b/app/assets/javascripts/models/param.jsx
@@ -63,6 +63,11 @@ define(function() {
       return this.isSavedForUser || this.isSavedForTeam;
     }
 
+    isSameNameAndTypeAs(otherParam) {
+      return this.name === otherParam.name &&
+        this.paramType.id === otherParam.paramType.id;
+    }
+
     clone(props) {
       return new Param(Object.assign({}, this, props));
     }


### PR DESCRIPTION
When checking whether params have changed, use a more specific test that looks at name and type only, since param objects can change on every save.