### PR TITLE
There's no good reason to be expiring param type valid values so quickly (or really at all), so stop doing it

### DIFF
--- a/app/models/behaviors/behaviorparameter/BehaviorParameterType.scala
+++ b/app/models/behaviors/behaviorparameter/BehaviorParameterType.scala
@@ -305,7 +305,7 @@ case class BehaviorBackedDataType(behavior: Behavior) extends BehaviorParameterT
             cancelAndRespondFor(s"This data type isn't returning any values: ${editLinkFor(context)}", context)
           } else {
             context.maybeConversation.foreach { conversation =>
-              context.cache.set(valuesListCacheKeyFor(conversation, context.parameter), validValues, 5.minutes)
+              context.cache.set(valuesListCacheKeyFor(conversation, context.parameter), validValues)
             }
             val valuesPrompt = validValues.zipWithIndex.map { case (ea, i) =>
               s"\n\n$i. ${ea.label}"


### PR DESCRIPTION


- should get rid of that weird behavior where, if you are asked for something by say a scheduled message, you get asked twice if you don't answer right away