### PR TITLE
Don't show the `@user asked me to say:` message when postMessage is called from within an ellipsis action

### DIFF
--- a/app/models/behaviors/events/APIMessageContext.scala
+++ b/app/models/behaviors/events/APIMessageContext.scala
@@ -27,7 +27,6 @@ case class APIMessageContext(
   def maybeDMChannel = {
     maybeSlackProfile.flatMap { slackProfile =>
       client.apiClient.listIms.find(_.user == slackProfile.loginInfo.providerKey).map(_.id)
-
     }
   }
   lazy val userIdForContext: String = maybeSlackProfile.map(_.loginInfo.providerKey).getOrElse(name)


### PR DESCRIPTION
- it should already be clear why the message is appearing