### PR TITLE
Remove the override on github caching, since it's unnecessary, and it…

### DIFF
--- a/conf/development.conf
+++ b/conf/development.conf
@@ -73,7 +73,7 @@ include "github.conf"
 
 memcached.host="127.0.0.1:11211"
 
-github.cacheTimeoutSeconds=30
+#github.cacheTimeoutSeconds=1800
 
 play.http.filters=filters.Filters
 play.http.errorHandler = "utils.ErrorHandler"


### PR DESCRIPTION
…'s easy to hit their rate limit otherwise