### PR TITLE
Trim whitespace from messages coming from slack

### DIFF
--- a/app/controllers/SlackController.scala
+++ b/app/controllers/SlackController.scala
@@ -118,7 +118,7 @@ class SlackController @Inject() (
         maybeProfile <- dataService.slackBotProfiles.allForSlackTeamId(info.teamId).map(_.headOption)
         _ <- maybeProfile.map { profile =>
           val event = info.event
-          slackEventService.onEvent(SlackMessageEvent(profile, event.channel, event.userId, event.text, event.ts))
+          slackEventService.onEvent(SlackMessageEvent(profile, event.channel, event.userId, event.text.trim, event.ts))
         }.getOrElse {
           Future.successful({})
         }


### PR DESCRIPTION
- do it globally so individual triggers don't need to worry about it
- this happens for example if you autocomplete in ios