### PR TITLE
Since we no longer have typing indication, try another approach with a loading message:

### DIFF
--- a/app/services/SlackEventService.scala
+++ b/app/services/SlackEventService.scala
@@ -9,6 +9,7 @@ import play.api.Logger
 import services.slack._
 
 import scala.concurrent.{Future, Promise}
+import scala.util.Random
 
 @Singleton
 class SlackEventService @Inject()(
@@ -20,8 +21,21 @@ class SlackEventService @Inject()(
   implicit val system = ActorSystem("slack")
   implicit val ec = system.dispatcher
 
+  lazy val loadingMessages = Seq(
+    ":drumroll:",
+    ":loading:"
+  )
+
+  val random = new Random()
+
+  def loadingMessage = {
+    val index = random.nextInt(loadingMessages.length)
+    loadingMessages(index)
+  }
+
   def onEvent(event: SlackMessageEvent): Future[Unit] = {
     if (!event.isBotMessage) {
+      val p = Promise[Unit]()
       val handleMessage = for {
         maybeConversation <- event.maybeOngoingConversation(dataService)
         _ <- eventHandler.handle(event, maybeConversation).flatMap { results =>
@@ -33,6 +47,21 @@ class SlackEventService @Inject()(
       handleMessage.recover {
         case t: Throwable => {
           Logger.error("Exception responding to a Slack message", t)
+        }
+      }
+      p.completeWith(handleMessage)
+      Future {
+        Thread.sleep(1500)
+        if (!p.isCompleted) {
+          event.client.postChatMessage(
+            event.channel,
+            loadingMessage,
+            asUser = Some(true),
+            unfurlLinks = None,
+            unfurlMedia = None
+          ).map { ts =>
+            p.future.onComplete(_ => event.client.deleteChat(event.channel, ts))
+          }
         }
       }
     } else {


### PR DESCRIPTION
- if an action takes longer than 1.5s to respond, show a loading message
- as soon as the action is done, delete that message