### PR TITLE
Make recurrences better account for timezones other than the system tz

### DIFF
--- a/test/RecurrenceSpec.scala
+++ b/test/RecurrenceSpec.scala
@@ -58,40 +58,40 @@ class RecurrenceSpec extends PlaySpec {
 
     "recur every day at noon" in  {
       val recurrence = Daily(1, LocalTime.parse("12:00:00"), timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-07T12:00")) mustBe DateTime.parse("2010-06-08T12:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 7, 12, 0, timeZone)) mustBe new DateTime(2010, 6, 8, 12, 0, timeZone)
     }
 
     "recur later the same day" in  {
       val recurrence = Daily(1, LocalTime.parse("12:00:00"), timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-07T11:50")) mustBe DateTime.parse("2010-06-07T12:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 7, 11, 50, timeZone)) mustBe new DateTime(2010, 6, 7, 12, 0, timeZone)
     }
 
     "recur later the next day if already past the target time" in  {
       val recurrence = Daily(1, LocalTime.parse("12:00:00"), timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-07T12:50")) mustBe DateTime.parse("2010-06-08T12:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 7, 12, 50, timeZone)) mustBe new DateTime(2010, 6, 8, 12, 0, timeZone)
     }
 
     "have the right initial time when earlier in the day" in {
       val recurrence = Daily(2, LocalTime.parse("12:00:00"), timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-06-07T11:59")) mustBe DateTime.parse("2010-06-07T12:00")
+      recurrence.initialAfter(new DateTime(2010, 6, 7, 11, 59, timeZone)) mustBe new DateTime(2010, 6, 7, 12, 0, timeZone)
     }
 
     "have the right initial time when later in the day" in {
       val recurrence = Daily(2, LocalTime.parse("12:00:00"), timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-06-07T12:01")) mustBe DateTime.parse("2010-06-08T12:00")
+      recurrence.initialAfter(new DateTime(2010, 6, 7, 12, 1, timeZone)) mustBe new DateTime(2010, 6, 8, 12, 0, timeZone)
     }
 
     "have the right initial time when at the same point in the day" in {
       val recurrence = Daily(2, LocalTime.parse("12:00:00"), timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-06-07T12:00")) mustBe DateTime.parse("2010-06-07T12:00")
+      recurrence.initialAfter(new DateTime(2010, 6, 7, 12, 0, timeZone)) mustBe new DateTime(2010, 6, 7, 12, 0, timeZone)
     }
 
     "be created with implied frequency of 1" in {
-      Recurrence.maybeFromText("every day", timeZone) mustBe Some(Daily(1, Recurrence.currentAdjustedTime, timeZone))
+      Recurrence.maybeFromText("every day", timeZone) mustBe Some(Daily(1, Recurrence.currentAdjustedTime(timeZone), timeZone))
     }
 
     "be created with frequency" in {
-      Recurrence.maybeFromText("every 4 days", timeZone) mustBe Some(Daily(4, Recurrence.currentAdjustedTime, timeZone))
+      Recurrence.maybeFromText("every 4 days", timeZone) mustBe Some(Daily(4, Recurrence.currentAdjustedTime(timeZone), timeZone))
     }
 
     "be created with frequency and time" in {
@@ -113,40 +113,40 @@ class RecurrenceSpec extends PlaySpec {
 
     "recur every second week at Monday, 2pm" in  {
       val recurrence = Weekly(2, 1, LocalTime.parse("14:00:00"), timeZone) // 1 is Monday
-      recurrence.nextAfter(DateTime.parse("2010-06-07T14:00")) mustBe DateTime.parse("2010-06-21T14:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 7, 14, 0, timeZone)) mustBe new DateTime(2010, 6, 21, 14, 0, timeZone)
     }
 
     "recur later in the week" in  {
       val recurrence = Weekly(1, 3, fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-08T12:01")) mustBe DateTime.parse("2010-06-09T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 8, 12, 1, timeZone)) mustBe new DateTime(2010, 6, 9, 17, 0, timeZone)
     }
 
     "recur the following week if already past target day" in  {
       val recurrence = Weekly(1, 3, fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-10T12:01")) mustBe DateTime.parse("2010-06-16T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 10, 12, 1, timeZone)) mustBe new DateTime(2010, 6, 16, 17, 0, timeZone)
     }
 
     "have the right initial time when earlier in the week" in {
       val recurrence = Weekly(2, 3, fivePM, timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-06-09T16:59")) mustBe DateTime.parse("2010-06-09T17:00")
+      recurrence.initialAfter(new DateTime(2010, 6, 9, 16, 59, timeZone)) mustBe new DateTime(2010, 6, 9, 17, 0, timeZone)
     }
 
     "have the right initial time when later in the week" in {
       val recurrence = Weekly(2, 3, fivePM, timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-06-09T17:01")) mustBe DateTime.parse("2010-06-16T17:00")
+      recurrence.initialAfter(new DateTime(2010, 6, 9, 17, 1, timeZone)) mustBe new DateTime(2010, 6, 16, 17, 0, timeZone)
     }
 
     "have the right initial time when at the same point in the week" in {
       val recurrence = Weekly(2, 3, fivePM, timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-06-09T17:00")) mustBe DateTime.parse("2010-06-09T17:00")
+      recurrence.initialAfter(new DateTime(2010, 6, 9, 17, 0, timeZone)) mustBe new DateTime(2010, 6, 9, 17, 0, timeZone)
     }
 
     "be created with implied frequency of 1" in {
-      Recurrence.maybeFromText("every week", timeZone) mustBe Some(Weekly(1, DateTime.now.getDayOfWeek, Recurrence.currentAdjustedTime, timeZone))
+      Recurrence.maybeFromText("every week", timeZone) mustBe Some(Weekly(1, DateTime.now.getDayOfWeek, Recurrence.currentAdjustedTime(timeZone), timeZone))
     }
 
     "be created with frequency" in {
-      Recurrence.maybeFromText("every 2 weeks", timeZone) mustBe Some(Weekly(2, DateTime.now.getDayOfWeek, Recurrence.currentAdjustedTime, timeZone))
+      Recurrence.maybeFromText("every 2 weeks", timeZone) mustBe Some(Weekly(2, DateTime.now.getDayOfWeek, Recurrence.currentAdjustedTime(timeZone), timeZone))
     }
 
     "be created with frequency, day of week and time" in {
@@ -159,37 +159,37 @@ class RecurrenceSpec extends PlaySpec {
 
     "recur the first of every second month, at 5pm" in  {
       val recurrence = MonthlyByDayOfMonth(2, 1, fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-07T12:01")) mustBe DateTime.parse("2010-08-01T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 7, 12, 1, timeZone)) mustBe new DateTime(2010, 8, 1, 17, 0, timeZone)
     }
 
     "recur later in the month if starting from earlier day in the month" in  {
       val recurrence = MonthlyByDayOfMonth(1, 6, fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-05T12:01")) mustBe DateTime.parse("2010-06-06T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 5, 12, 1, timeZone)) mustBe new DateTime(2010, 6, 6, 17, 0, timeZone)
     }
 
     "recur later in the day if starting from earlier time in target day" in  {
       val recurrence = MonthlyByDayOfMonth(1, 6, fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-06T12:01")) mustBe DateTime.parse("2010-06-06T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 6, 12, 1, timeZone)) mustBe new DateTime(2010, 6, 6, 17, 0, timeZone)
     }
 
     "recur next month if starting later in the month" in  {
       val recurrence = MonthlyByDayOfMonth(1, 6, fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-06T17:01")) mustBe DateTime.parse("2010-07-06T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 6, 17, 1, timeZone)) mustBe new DateTime(2010, 7, 6, 17, 0, timeZone)
     }
 
     "have the right initial time when earlier in the month" in {
       val recurrence = MonthlyByDayOfMonth(1, 6, fivePM, timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-06-06T16:59")) mustBe DateTime.parse("2010-06-06T17:00")
+      recurrence.initialAfter(new DateTime(2010, 6, 6, 16, 59, timeZone)) mustBe new DateTime(2010, 6, 6, 17, 0, timeZone)
     }
 
     "have the right initial time when later in the month" in {
       val recurrence = MonthlyByDayOfMonth(1, 6, fivePM, timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-06-06T17:01")) mustBe DateTime.parse("2010-07-06T17:00")
+      recurrence.initialAfter(new DateTime(2010, 6, 6, 17, 1, timeZone)) mustBe new DateTime(2010, 7, 6, 17, 0, timeZone)
     }
 
     "have the right initial time when at the same point in the month" in {
       val recurrence = MonthlyByDayOfMonth(1, 6, fivePM, timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-06-06T17:00")) mustBe DateTime.parse("2010-06-06T17:00")
+      recurrence.initialAfter(new DateTime(2010, 6, 6, 17, 0, timeZone)) mustBe new DateTime(2010, 6, 6, 17, 0, timeZone)
     }
 
     "be created with first day of every month" in {
@@ -206,47 +206,47 @@ class RecurrenceSpec extends PlaySpec {
 
     "recur the second Tuesday of every month, at 5pm" in  {
       val recurrence = MonthlyByNthDayOfWeek(1, 2, 2, fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-07T12:01")) mustBe DateTime.parse("2010-06-08T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 7, 12, 1, timeZone)) mustBe new DateTime(2010, 6, 8, 17, 0, timeZone)
     }
 
     "recur correctly when month starts with the target day of week" in  {
       val recurrence = MonthlyByNthDayOfWeek(1, 4, 1, fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-07T12:01")) mustBe DateTime.parse("2010-07-01T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 7, 12, 1, timeZone)) mustBe new DateTime(2010, 7, 1, 17, 0, timeZone)
     }
 
     "recur correctly when month starts with a day before the target day of week" in  {
       val recurrence = MonthlyByNthDayOfWeek(1, 5, 1, fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-07T12:01")) mustBe DateTime.parse("2010-07-02T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 7, 12, 1, timeZone)) mustBe new DateTime(2010, 7, 2, 17, 0, timeZone)
     }
 
     "recur correctly when month starts with a day after the target day of week" in  {
       val recurrence = MonthlyByNthDayOfWeek(1, 3, 1, fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-07T12:01")) mustBe DateTime.parse("2010-07-07T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 7, 12, 1, timeZone)) mustBe new DateTime(2010, 7, 7, 17, 0, timeZone)
     }
 
     "recur later the same month if starting from earlier in the month" in  {
       val recurrence = MonthlyByNthDayOfWeek(1, 1, 1, fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-06T12:01")) mustBe DateTime.parse("2010-06-07T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 6, 12, 1, timeZone)) mustBe new DateTime(2010, 6, 7, 17, 0, timeZone)
     }
 
     "recur later the same month if starting from earlier in the target day" in  {
       val recurrence = MonthlyByNthDayOfWeek(1, 1, 1, fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-07T12:01")) mustBe DateTime.parse("2010-06-07T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 7, 12, 1, timeZone)) mustBe new DateTime(2010, 6, 7, 17, 0, timeZone)
     }
 
     "have the right initial time when earlier in the month" in {
       val recurrence = MonthlyByNthDayOfWeek(1, 1, 1, fivePM, timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-06-07T16:59")) mustBe DateTime.parse("2010-06-07T17:00")
+      recurrence.initialAfter(new DateTime(2010, 6, 7, 16, 59, timeZone)) mustBe new DateTime(2010, 6, 7, 17, 0, timeZone)
     }
 
     "have the right initial time when later in the month" in {
       val recurrence = MonthlyByNthDayOfWeek(1, 1, 1, fivePM, timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-06-07T17:01")) mustBe DateTime.parse("2010-07-05T17:00")
+      recurrence.initialAfter(new DateTime(2010, 6, 7, 17, 1, timeZone)) mustBe new DateTime(2010, 7, 5, 17, 0, timeZone)
     }
 
     "have the right initial time when at the same point in the month" in {
       val recurrence = MonthlyByNthDayOfWeek(1, 1, 1, fivePM, timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-06-07T17:00")) mustBe DateTime.parse("2010-06-07T17:00")
+      recurrence.initialAfter(new DateTime(2010, 6, 7, 17, 0, timeZone)) mustBe new DateTime(2010, 6, 7, 17, 0, timeZone)
     }
 
     "be created with first monday of every month" in {
@@ -263,37 +263,37 @@ class RecurrenceSpec extends PlaySpec {
 
     "recur Jan 14 every year, at 5pm" in  {
       val recurrence = Yearly(1, new MonthDay(1, 14), fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-06-07T12:01")) mustBe DateTime.parse("2011-01-14T17:00")
+      recurrence.nextAfter(new DateTime(2010, 6, 7, 12, 1, timeZone)) mustBe new DateTime(2011, 1, 14, 17, 0, timeZone)
     }
 
     "recur later the same year" in  {
       val recurrence = Yearly(1, new MonthDay(1, 14), fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-01-13T12:01")) mustBe DateTime.parse("2010-01-14T17:00")
+      recurrence.nextAfter(new DateTime(2010, 1, 13, 12, 1, timeZone)) mustBe new DateTime(2010, 1, 14, 17, 0, timeZone)
     }
 
     "recur later the same day" in  {
       val recurrence = Yearly(1, new MonthDay(1, 14), fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-01-14T12:01")) mustBe DateTime.parse("2010-01-14T17:00")
+      recurrence.nextAfter(new DateTime(2010, 1, 14, 12, 1, timeZone)) mustBe new DateTime(2010, 1, 14, 17, 0, timeZone)
     }
 
     "recur the next year" in  {
       val recurrence = Yearly(1, new MonthDay(1, 14), fivePM, timeZone)
-      recurrence.nextAfter(DateTime.parse("2010-01-14T17:01")) mustBe DateTime.parse("2011-01-14T17:00")
+      recurrence.nextAfter(new DateTime(2010, 1, 14, 17, 1, timeZone)) mustBe new DateTime(2011, 1, 14, 17, 0, timeZone)
     }
 
     "have the right initial time when earlier in the year" in {
       val recurrence = Yearly(1, new MonthDay(1, 14), fivePM, timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-01-14T16:59")) mustBe DateTime.parse("2010-01-14T17:00")
+      recurrence.initialAfter(new DateTime(2010, 1, 14, 16, 59, timeZone)) mustBe new DateTime(2010, 1, 14, 17, 0, timeZone)
     }
 
     "have the right initial time when later in the year" in {
       val recurrence = Yearly(1, new MonthDay(1, 14), fivePM, timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-01-14T17:01")) mustBe DateTime.parse("2011-01-14T17:00")
+      recurrence.initialAfter(new DateTime(2010, 1, 14, 17, 1, timeZone)) mustBe new DateTime(2011, 1, 14, 17, 0, timeZone)
     }
 
     "have the right initial time when at the same point in the year" in {
       val recurrence = Yearly(1, new MonthDay(1, 14), fivePM, timeZone)
-      recurrence.initialAfter(DateTime.parse("2010-01-14T17:00")) mustBe DateTime.parse("2010-01-14T17:00")
+      recurrence.initialAfter(new DateTime(2010, 1, 14, 17, 0, timeZone)) mustBe new DateTime(2010, 1, 14, 17, 0, timeZone)
     }
 
     "be created for the 14th of January every year" in {
@@ -301,7 +301,7 @@ class RecurrenceSpec extends PlaySpec {
     }
 
     "be created for every second January 14th with no time specified" in {
-      val time = Recurrence.currentAdjustedTime
+      val time = Recurrence.currentAdjustedTime(timeZone)
       Recurrence.maybeFromText("every 2nd year on January 14", timeZone) mustBe Some(Yearly(2, new MonthDay(1, 14), time, timeZone))
     }
 


### PR DESCRIPTION
- I think this should fix the weird repeated scheduled message issue (which only happened at times of day where UTC time was on the next day from the team time)
- as a bonus, recurrence tests now pass when run in other timezones :)