### PR TITLE
cascade deletes from behaviors to invocation tokens, so behavior deletes aren't blocked

### DIFF
--- a/conf/evolutions/default/67.sql
+++ b/conf/evolutions/default/67.sql
@@ -1,0 +1,19 @@
+# --- !Ups
+
+TRUNCATE TABLE invocation_tokens;
+ALTER TABLE invocation_tokens
+DROP CONSTRAINT invocation_tokens_behavior_id_fkey,
+ADD CONSTRAINT invocation_tokens_behavior_id_fkey
+  FOREIGN KEY(behavior_id)
+  REFERENCES behaviors(id)
+  ON DELETE CASCADE;
+
+# --- !Downs
+
+TRUNCATE TABLE invocation_tokens;
+ALTER TABLE invocation_tokens
+DROP CONSTRAINT invocation_tokens_behavior_id_fkey,
+ADD CONSTRAINT invocation_tokens_behavior_id_fkey
+  FOREIGN KEY(behavior_id)
+  REFERENCES behaviors(id)
+  ON DELETE SET NULL;


### PR DESCRIPTION
- this will be revisited when/if we move to soft deletes