### PR TITLE
Try to speed up code editor

### DIFF
--- a/app/assets/javascripts/behavior_editor/code_editor.jsx
+++ b/app/assets/javascripts/behavior_editor/code_editor.jsx
@@ -118,6 +118,11 @@ return React.createClass({
     };
   },
 
+  replaceTabsWithSpaces: function(cm) {
+    var spaces = Array(cm.getOption("indentUnit") + 1).join(" ");
+    cm.replaceSelection(spaces);
+  },
+
   render: function() {
     return (
       <Codemirror value={this.props.value}
@@ -126,7 +131,7 @@ return React.createClass({
         options={{
           mode: "javascript",
           firstLineNumber: this.props.firstLineNumber,
-          gutters: ["CodeMirror-lint-markers"],
+          gutters: ["CodeMirror-lint-markers","CodeMirror-linenumbers"],
           hintOptions: { hint: this.autocompleteParams },
           indentUnit: 2,
           indentWithTabs: false,
@@ -138,10 +143,7 @@ return React.createClass({
           viewportMargin: Infinity,
           extraKeys: {
             Esc: "autocomplete",
-            Tab: function(cm) {
-              var spaces = Array(cm.getOption("indentUnit") + 1).join(" ");
-              cm.replaceSelection(spaces);
-            }
+            Tab: this.replaceTabsWithSpaces
           }
         }}
       />

--- a/app/assets/javascripts/behavior_editor/response_template_configuration.jsx
+++ b/app/assets/javascripts/behavior_editor/response_template_configuration.jsx
@@ -139,12 +139,7 @@ define(function(require) {
                 onChange={this.props.onChangeTemplate}
                 onCursorChange={this.props.onCursorChange}
                 options={{
-                  mode: {
-                    name: "markdown",
-                    /* Use CommonMark-appropriate settings */
-                    fencedCodeBlocks: true,
-                    underscoresBreakWords: false
-                  },
+                  mode: "gfm",
                   gutters: ['CodeMirror-no-gutter'],
                   indentUnit: 4,
                   indentWithTabs: true,

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ libraryDependencies ++= Seq(
   "org.webjars.bower" % "core.js" % "2.4.1",
   "org.webjars.bower" % "react" % "15.3.1",
   "org.webjars.bower" % "fetch" % "1.0.0",
-  "org.webjars.bower" % "codemirror" % "5.15.2",
+  "org.webjars.bower" % "codemirror" % "5.22.2",
   "org.webjars.bower" % "jshint" % "2.9.2",
   "org.webjars.bower" % "javascript-debounce" % "1.0.0",
   "org.webjars.bower" % "moment" % "2.14.1",


### PR DESCRIPTION
Attempt to resolve #1195 

Upgrade codemirror to latest, and try to cut down on number of option updates to improve speed

This switches to codemirror's new github-flavored markdown (GFM) mode.