### PR TITLE
Increase the lifespan of an invocation token from 10 seconds to 15

### DIFF
--- a/app/models/behaviors/invocationtoken/InvocationToken.scala
+++ b/app/models/behaviors/invocationtoken/InvocationToken.scala
@@ -8,5 +8,6 @@ case class InvocationToken(
                             behaviorId: String,
                             createdAt: OffsetDateTime
                           ) {
-  def isExpired: Boolean = createdAt.isBefore(OffsetDateTime.now.minusSeconds(10))
+  // Ellipsis's function time out is 10 seconds, but there can be a delay in starting, so we allow an extra 5
+  def isExpired: Boolean = createdAt.isBefore(OffsetDateTime.now.minusSeconds(15))
 }


### PR DESCRIPTION
It seems like AWS sometimes doesn't finish within 10 seconds, and it's possible to get an invalid token despite the function itself not taking more than 10 seconds. Trying a longer lifespan to avoid this problem.