### PR TITLE
Stop making login tokens be one-time use

### DIFF
--- a/app/controllers/SocialAuthController.scala
+++ b/app/controllers/SocialAuthController.scala
@@ -209,7 +209,6 @@ class SocialAuthController @Inject() (
           Future.successful(Redirect(successRedirect))
         } else if (token.isValid) {
           for {
-            _ <- dataService.loginTokens.use(token)
             maybeUser <- dataService.users.find(token.userId)
             resultForValidToken <- maybeUser.map { user =>
               authenticatorResultForUserAndResult(user, Redirect(successRedirect))

--- a/app/models/accounts/logintoken/LoginToken.scala
+++ b/app/models/accounts/logintoken/LoginToken.scala
@@ -5,13 +5,12 @@ import java.time.OffsetDateTime
 case class LoginToken(
                         value: String,
                         userId: String,
-                        isUsed: Boolean,
                         createdAt: OffsetDateTime
                       ) {
 
   def isExpired: Boolean = createdAt.isBefore(LoginToken.expiryCutoff)
 
-  def isValid: Boolean = !isUsed && !isExpired
+  def isValid: Boolean = !isExpired
 
 }
 

--- a/app/models/accounts/logintoken/LoginTokenService.scala
+++ b/app/models/accounts/logintoken/LoginTokenService.scala
@@ -7,5 +7,4 @@ import scala.concurrent.Future
 trait LoginTokenService {
   def find(value: String): Future[Option[LoginToken]]
   def createFor(user: User): Future[LoginToken]
-  def use(loginToken: LoginToken): Future[Unit]
 }

--- a/app/models/accounts/logintoken/LoginTokenServiceImpl.scala
+++ b/app/models/accounts/logintoken/LoginTokenServiceImpl.scala
@@ -15,10 +15,9 @@ import scala.concurrent.Future
 class LoginTokensTable(tag: Tag) extends Table[LoginToken](tag, "login_tokens") {
   def value = column[String]("value")
   def userId = column[String]("user_id")
-  def isUsed = column[Boolean]("is_used")
   def createdAt = column[OffsetDateTime]("created_at")
 
-  def * = (value, userId, isUsed, createdAt) <> ((LoginToken.apply _).tupled, LoginToken.unapply _)
+  def * = (value, userId, createdAt) <> ((LoginToken.apply _).tupled, LoginToken.unapply _)
 }
 
 class LoginTokenServiceImpl @Inject() (dataServiceProvider: Provider[DataService]) extends LoginTokenService {
@@ -36,12 +35,8 @@ class LoginTokenServiceImpl @Inject() (dataServiceProvider: Provider[DataService
     dataService.run(findQuery(value).result.map(_.headOption))
   }
 
-  def use(loginToken: LoginToken): Future[Unit] = {
-    dataService.run(all.filter(_.value === loginToken.value).map(_.isUsed).update(true).map(_ => Unit))
-  }
-
   def createFor(user: User): Future[LoginToken] = {
-    val instance = LoginToken(IDs.next, user.id, isUsed = false, OffsetDateTime.now)
+    val instance = LoginToken(IDs.next, user.id, OffsetDateTime.now)
     dataService.run((all += instance).map(_ => instance))
   }
 

--- a/conf/evolutions/default/71.sql
+++ b/conf/evolutions/default/71.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+
+ALTER TABLE login_tokens DROP COLUMN is_used;
+
+# --- !Downs
+
+ALTER TABLE login_tokens ADD COLUMN is_used BOOL NOT NULL DEFAULT FALSE;

--- a/test/controllers/APIAccessControllerSpec.scala
+++ b/test/controllers/APIAccessControllerSpec.scala
@@ -4,10 +4,8 @@ import java.time.OffsetDateTime
 
 import com.mohiva.play.silhouette.test._
 import models.IDs
-import models.accounts.logintoken.LoginToken
 import models.accounts.oauth2api.{AuthorizationCode, OAuth2Api}
 import models.accounts.oauth2application.OAuth2Application
-import models.accounts.user.User
 import models.team.Team
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
@@ -19,8 +17,6 @@ import support.ControllerTestContextWithLoggedInUser
 import scala.concurrent.Future
 
 class APIAccessControllerSpec extends PlaySpec with MockitoSugar {
-
-  def newLoginTokenFor(user: User, isUsed: Boolean = false): LoginToken = LoginToken(IDs.next, user.id, isUsed, OffsetDateTime.now)
 
   "APIAccessController.linkCustomOAuth2Service" should {
 

--- a/test/controllers/SocialAuthControllerSpec.scala
+++ b/test/controllers/SocialAuthControllerSpec.scala
@@ -17,7 +17,14 @@ import scala.concurrent.Future
 
 class SocialAuthControllerSpec extends PlaySpec with MockitoSugar {
 
-  def newLoginTokenFor(user: User, isUsed: Boolean = false): LoginToken = LoginToken(IDs.next, user.id, isUsed, OffsetDateTime.now)
+  def newLoginTokenFor(user: User, isExpired: Boolean = false): LoginToken = {
+    val createdAt = if (isExpired) {
+      OffsetDateTime.now.minusSeconds(LoginToken.EXPIRY_SECONDS + 1)
+    } else {
+      OffsetDateTime.now
+    }
+    LoginToken(IDs.next, user.id, createdAt)
+  }
 
   "SocialAuthController.loginWithToken" should {
 
@@ -37,7 +44,6 @@ class SocialAuthControllerSpec extends PlaySpec with MockitoSugar {
         val validToken = newLoginTokenFor(user)
         when(dataService.loginTokens.find(validToken.value)).thenReturn(Future.successful(Some(validToken)))
         when(dataService.users.find(validToken.userId)).thenReturn(Future.successful(Some(user)))
-        when(dataService.loginTokens.use(validToken)).thenReturn(Future.successful({}))
         val result = route(app, FakeRequest(controllers.routes.SocialAuthController.loginWithToken(validToken.value, Some(redirect)))).get
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some(redirect)
@@ -48,7 +54,7 @@ class SocialAuthControllerSpec extends PlaySpec with MockitoSugar {
 
     "Don't log in and inform the user if invalid token" in new ControllerTestContext {
       running(app) {
-        val invalidToken = newLoginTokenFor(user, isUsed = true)
+        val invalidToken = newLoginTokenFor(user, isExpired = true)
         when(dataService.loginTokens.find(invalidToken.value)).thenReturn(Future.successful(Some(invalidToken)))
         val result = route(app, FakeRequest(controllers.routes.SocialAuthController.loginWithToken(invalidToken.value, Some(redirect)))).get
         status(result) mustBe OK
@@ -64,7 +70,6 @@ class SocialAuthControllerSpec extends PlaySpec with MockitoSugar {
         val validToken = newLoginTokenFor(initiallyLoggedOutUser)
         when(dataService.loginTokens.find(validToken.value)).thenReturn(Future.successful(Some(validToken)))
         when(dataService.users.find(validToken.userId)).thenReturn(Future.successful(Some(initiallyLoggedOutUser)))
-        when(dataService.loginTokens.use(validToken)).thenReturn(Future.successful({}))
         val request = FakeRequest(controllers.routes.SocialAuthController.loginWithToken(validToken.value, Some(redirect))).withAuthenticator(user.loginInfo)
         val result = route(app, request).get
         status(result) mustBe SEE_OTHER
@@ -76,7 +81,7 @@ class SocialAuthControllerSpec extends PlaySpec with MockitoSugar {
 
     "Redirect correctly, ignore the token, don't log in if already logged in as correct user" in new ControllerTestContextWithLoggedInUser {
       running(app) {
-        val alreadyUsedToken = newLoginTokenFor(user, isUsed = true)
+        val alreadyUsedToken = newLoginTokenFor(user, isExpired = true)
         when(dataService.loginTokens.find(alreadyUsedToken.value)).thenReturn(Future.successful(Some(alreadyUsedToken)))
         val request = FakeRequest(controllers.routes.SocialAuthController.loginWithToken(alreadyUsedToken.value, Some(redirect))).withAuthenticator(user.loginInfo)
         val result = route(app, request).get


### PR DESCRIPTION
 - slack sometimes visits links posted, which can invalidate a one-time-use token
 - i can't think of why we care that it's one-time-use anyway, since we only post links with login tokens in DM or other private channels