### PR TITLE
Ensure &, < and > aren't escaped in button labels

### DIFF
--- a/app/controllers/SlackController.scala
+++ b/app/controllers/SlackController.scala
@@ -341,7 +341,14 @@ class SlackController @Inject() (
         BadRequest(formWithErrors.errorsAsJson)
       },
       payload => {
-        Json.parse(payload).validate[ActionsTriggeredInfo] match {
+
+        // Slack improperly (?) displays escaped text inside button labels as-is in the client when
+        // we return the original message back.
+        //
+        // TODO: Investigate whether this is safe and/or desirable
+        val unescapedPayload = payload.replaceAll("&amp;", "&").replaceAll("&lt;", "<").replaceAll("&gt;", ">")
+
+        Json.parse(unescapedPayload).validate[ActionsTriggeredInfo] match {
           case JsSuccess(info, jsPath) => {
             if (info.isValid) {
               var resultText: String = "OK, let’s continue."


### PR DESCRIPTION
For now, unescape &, < and > in the payload when responding to Slack action requests, because Slack improperly preserves the escaping in button labels when we return it back to them.