### PR TITLE
Change the Input semantics such that having a groupId no longer means…

### DIFF
--- a/app/assets/javascripts/behavior_editor/index.jsx
+++ b/app/assets/javascripts/behavior_editor/index.jsx
@@ -116,8 +116,7 @@ const BehaviorEditor = React.createClass({
       return arr.concat(ea.params);
     }, [])
       .filter(ea => currentInputIds.indexOf(ea.inputId) === -1)
-      .filter(ea => ea.isSaved())
-      .map(ea => ea.clone({ groupId: this.props.behavior.groupId }));
+      .filter(ea => ea.isSaved());
     return UniqueBy.forArray(all, 'inputId');
   },
 
@@ -1968,6 +1967,7 @@ const BehaviorEditor = React.createClass({
             isFinishedBehavior={this.isFinishedBehavior()}
             behaviorHasCode={this.state.revealCodeEditor}
             hasSharedAnswers={this.getOtherSavedParametersInGroup().length > 0}
+            otherBehaviorsInGroup={this.props.otherBehaviorsInGroup}
             onToggleSharedAnswer={this.toggleSharedAnswerInputSelector}
             savedAnswers={this.props.savedAnswers}
             onToggleSavedAnswer={this.toggleSavedAnswerEditor}

--- a/app/assets/javascripts/behavior_editor/user_input_configuration.jsx
+++ b/app/assets/javascripts/behavior_editor/user_input_configuration.jsx
@@ -4,6 +4,7 @@ define(function(require) {
     UserInputDefinition = require('./user_input_definition'),
     Checklist = require('./checklist'),
     Collapsible = require('../shared_ui/collapsible'),
+    BehaviorVersion = require('../models/behavior_version'),
     Param = require('../models/param'),
     Trigger = require('../models/trigger');
 
@@ -27,6 +28,7 @@ define(function(require) {
       isFinishedBehavior: React.PropTypes.bool.isRequired,
       behaviorHasCode: React.PropTypes.bool.isRequired,
       hasSharedAnswers: React.PropTypes.bool.isRequired,
+      otherBehaviorsInGroup: React.PropTypes.arrayOf(React.PropTypes.instanceOf(BehaviorVersion)).isRequired,
       onToggleSharedAnswer: React.PropTypes.func.isRequired,
       savedAnswers: React.PropTypes.arrayOf(
         React.PropTypes.shape({
@@ -62,6 +64,14 @@ define(function(require) {
 
     hasParams: function() {
       return this.props.userParams.length > 0;
+    },
+
+    isShared: function(param) {
+      const firstBehaviorWithSameInput = this.props.otherBehaviorsInGroup.find(behavior => {
+        const inputIds = behavior.params.map(ea => ea.inputId);
+        return inputIds.indexOf(param.inputId) !== -1;
+      });
+      return !!firstBehaviorWithSameInput;
     },
 
     countLinkedTriggersForParam: function(paramName, paramIndex) {
@@ -156,6 +166,7 @@ define(function(require) {
                           key={'UserInputDefinition' + paramIndex}
                           ref={'param' + paramIndex}
                           param={param}
+                          isShared={this.isShared(param)}
                           paramTypes={this.props.paramTypes}
                           onChange={this.onChange.bind(this, paramIndex)}
                           onDelete={this.onDelete.bind(this, paramIndex)}

--- a/app/assets/javascripts/behavior_editor/user_input_definition.jsx
+++ b/app/assets/javascripts/behavior_editor/user_input_definition.jsx
@@ -20,6 +20,7 @@ return React.createClass({
       React.PropTypes.string
     ]).isRequired,
     param: React.PropTypes.instanceOf(Param).isRequired,
+    isShared: React.PropTypes.bool.isRequired,
     paramTypes: React.PropTypes.arrayOf(
       React.PropTypes.shape({
         id: React.PropTypes.string,
@@ -169,7 +170,7 @@ return React.createClass({
   },
 
   renderSharingInfo: function() {
-    if (this.props.param.isShared()) {
+    if (this.props.isShared) {
       return (
         <div className="box-tip mbneg1 plm">
           <span className="display-inline-block align-b type-pink mrs" style={{ height: 24 }}>

--- a/app/assets/javascripts/models/param.jsx
+++ b/app/assets/javascripts/models/param.jsx
@@ -16,8 +16,7 @@ define(function() {
         isSavedForTeam: false,
         isSavedForUser: false,
         inputId: null,
-        inputExportId: null,
-        groupId: null
+        inputExportId: null
       }, props);
 
       // TODO: We can re-enable this once all published skills have params with param types
@@ -52,16 +51,8 @@ define(function() {
         inputExportId: {
           value: initialProps.inputExportId,
           enumerable: true
-        },
-        groupId: {
-          value: initialProps.groupId,
-          enumerable: true
         }
       });
-    }
-
-    isShared() {
-      return !!this.groupId;
     }
 
     isSaved() {

--- a/app/json/InputData.scala
+++ b/app/json/InputData.scala
@@ -18,13 +18,10 @@ case class InputData(
                       groupId: Option[String]
                     ) {
 
-  val isShared = groupId.isDefined
-
   val maybeNonEmptyQuestion: Option[String] = Option(question).filter(_.nonEmpty)
 
   def copyForExport(groupExporter: BehaviorGroupExporter): InputData = {
-    val maybeExportGroupId = groupId.flatMap { _ => groupExporter.behaviorGroup.maybeExportId }
-    copy(id = None, paramType = paramType.map(_.copyForExport(groupExporter)), groupId = maybeExportGroupId)
+    copy(id = None, paramType = paramType.map(_.copyForExport(groupExporter)))
   }
 
 }

--- a/app/models/behaviors/input/Input.scala
+++ b/app/models/behaviors/input/Input.scala
@@ -16,8 +16,6 @@ case class Input(
 
   val isSaved = isSavedForTeam || isSavedForUser
 
-  def isShared = maybeBehaviorGroup.isDefined
-
   def question: String = maybeQuestion.getOrElse(s"What is the value for `$name`?")
 
   def toRaw: RawInput = {

--- a/app/models/behaviors/savedanswer/SavedAnswerServiceImpl.scala
+++ b/app/models/behaviors/savedanswer/SavedAnswerServiceImpl.scala
@@ -96,8 +96,12 @@ class SavedAnswerServiceImpl @Inject() (
 
   def updateForInputId(maybeOldInputId: Option[String], newInputId: String): Future[Unit] = {
     maybeOldInputId.map { oldInputId =>
-      val action = all.filter(_.inputId === oldInputId).map(_.inputId).update(newInputId).map(_ => {})
-      dataService.run(action)
+      if (oldInputId != newInputId) {
+        val action = all.filter(_.inputId === oldInputId).map(_.inputId).update(newInputId).map(_ => {})
+        dataService.run(action)
+      } else {
+        Future.successful({})
+      }
     }.getOrElse(Future.successful({}))
   }
 

--- a/conf/evolutions/default/83.sql
+++ b/conf/evolutions/default/83.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+
+UPDATE inputs as i SET group_id =
+  (SELECT DISTINCT(b.group_id) FROM behavior_parameters as bp
+    JOIN behavior_versions as bv ON bp.behavior_version_id = bv.id
+    JOIN behaviors as b ON bv.behavior_id = b.id
+  WHERE bp.input_id = i.id);
+
+# --- !Downs

--- a/test/BehaviorGroupImportExportSpec.scala
+++ b/test/BehaviorGroupImportExportSpec.scala
@@ -84,8 +84,9 @@ class BehaviorGroupImportExportSpec extends DBSpec {
 
         mustBeValidImport(exportedGroup, importedGroup)
 
-        val importedSharedInputs = runNow(dataService.inputs.allForGroup(importedGroup))
-        importedSharedInputs must have length 0
+        val importedInputs = runNow(dataService.inputs.allForGroup(importedGroup))
+        importedInputs must have length 2
+        importedInputs.head.id mustNot be(importedInputs.tail.head.id)
         val importedBehaviors = runNow(dataService.behaviors.allForGroup(importedGroup))
         val importedVersions = runNow(Future.sequence(importedBehaviors.map { behavior =>
           dataService.behaviors.maybeCurrentVersionFor(behavior)
@@ -165,8 +166,8 @@ class BehaviorGroupImportExportSpec extends DBSpec {
 
         mustBeValidImport(exportedGroup, importedGroup)
 
-        val importedSharedInputs = runNow(dataService.inputs.allForGroup(importedGroup))
-        importedSharedInputs must have length 0
+        val importedInputs = runNow(dataService.inputs.allForGroup(importedGroup))
+        importedInputs must have length 1
         val importedDataTypes = runNow(dataService.behaviors.dataTypesForGroup(importedGroup))
         importedDataTypes must have length 1
         val importedBehaviors = runNow(dataService.behaviors.regularForGroup(importedGroup))

--- a/test/behavior_editor_spec.js
+++ b/test/behavior_editor_spec.js
@@ -114,7 +114,7 @@ describe('BehaviorEditor', () => {
 
   describe('getBehaviorParams', () => {
     it('returns the defined parameters', () => {
-      editorConfig.behavior.params = [{ name: 'clown', question: 'what drives the car?', paramType: editorConfig.paramTypes[0], isSavedForTeam: false, isSavedForUser: true, inputId: "abcd1234", inputExportId: null, groupId: null }];
+      editorConfig.behavior.params = [{ name: 'clown', question: 'what drives the car?', paramType: editorConfig.paramTypes[0], isSavedForTeam: false, isSavedForUser: true, inputId: "abcd1234", inputExportId: null }];
       let editor = createEditor(editorConfig);
       expect(editor.getBehaviorParams()).toEqual(editorConfig.behavior.params);
     });

--- a/test/support/DBSpec.scala
+++ b/test/support/DBSpec.scala
@@ -64,7 +64,7 @@ trait DBSpec extends PlaySpec with OneAppPerSuite {
                       ): BehaviorParameter = {
     val input = maybeExistingInput.map { input =>
       runNow(InputData.fromInput(input, dataService).flatMap { inputData =>
-        dataService.inputs.ensureFor(inputData.copy(groupId = version.behavior.maybeGroup.map(_.id)), version.group)
+        dataService.inputs.ensureFor(inputData, version.group)
       })
     }.getOrElse {
       val inputData = InputData(Some(IDs.next), None, "param", maybeType, "", isSavedForTeam.exists(identity), isSavedForUser.exists(identity), None)


### PR DESCRIPTION
… it is shared

- we already can tell if it's shared by just checking if multiple behavior params refer to the same input
- now, groupId on input just means that's the group it belongs to (there should only be one)
- in a future change, i'll make group_id required on the inputs table