### PR TITLE
Fix sticky component scroll/render issues:

### DIFF
--- a/app/assets/javascripts/shared_ui/sticky.jsx
+++ b/app/assets/javascripts/shared_ui/sticky.jsx
@@ -1,5 +1,6 @@
 define(function(require) {
-  var React = require('react');
+  var React = require('react'),
+    DeepEqual = require('../lib/deep_equal');
 
   function setStyles(element, styles) {
     if (element && element.style) {
@@ -19,12 +20,21 @@ define(function(require) {
       outerClassName: React.PropTypes.string
     },
 
+    scrollTopPosition: 0,
+
+    lastCoords: {},
+
     resetCoordinates: function() {
       if (!this.innerContainer) {
         return;
       }
 
       var coords = this.props.onGetCoordinates();
+      if (DeepEqual.isEqual(coords, this.lastCoords)) {
+        return;
+      }
+
+      this.lastCoords = coords;
 
       setStyles(this.placeholder, { width: "" });
       setStyles(this.outerContainer, { height: "" });
@@ -50,6 +60,8 @@ define(function(require) {
 
         setStyles(this.placeholder, { width: `${newWidth}px` });
       }
+
+      this.innerContainer.scrollTop = this.scrollTopPosition;
     },
 
     componentDidMount: function() {
@@ -59,6 +71,10 @@ define(function(require) {
 
       window.addEventListener('resize', this.resetCoordinates, false);
       this.resetCoordinates();
+    },
+
+    componentWillUpdate: function() {
+      this.scrollTopPosition = this.innerContainer ? this.innerContainer.scrollTop : 0;
     },
 
     componentDidUpdate: function(prevProps) {


### PR DESCRIPTION
- don't make any adjustments if the coordinates reported are the same as last time
- try to reset scroll position when re-rendering happens, if necessary