### PR TITLE
Don't allow blank names in data type dropdown, and sort the data types alphabetically

### DIFF
--- a/app/assets/javascripts/behavior_editor/index.jsx
+++ b/app/assets/javascripts/behavior_editor/index.jsx
@@ -527,7 +527,8 @@ const BehaviorEditor = React.createClass({
   },
 
   getParamTypes: function() {
-    return this.props.builtinParamTypes.concat(this.getBehaviorGroup().getCustomParamTypes());
+    var customTypes = Sort.arrayAlphabeticalBy(this.getBehaviorGroup().getCustomParamTypes(), (ea) => ea.name);
+    return this.props.builtinParamTypes.concat(customTypes);
   },
 
   /* Setters/togglers */

--- a/app/assets/javascripts/models/behavior_version.jsx
+++ b/app/assets/javascripts/models/behavior_version.jsx
@@ -97,7 +97,7 @@ define(function(require) {
       return {
         id: this.id,
         exportId: this.exportId,
-        name: this.name,
+        name: this.name || "Unnamed data type",
         needsConfig: this.needsConfig()
       };
     }


### PR DESCRIPTION
Ensure param types have a name for display purposes, since the input config section expects them to have one for the dropdown menu.
