### PR TITLE
One skill to install is okay

### DIFF
--- a/app/assets/javascripts/behavior_list/index.jsx
+++ b/app/assets/javascripts/behavior_list/index.jsx
@@ -325,7 +325,16 @@ define(function(require) {
 
     renderPublishedGroups: function() {
       var groups = this.getUninstalledBehaviorGroups();
-      if (this.props.publishedBehaviorGroupLoadStatus === 'loaded' && groups.length > 1) {
+      if (this.props.publishedBehaviorGroupLoadStatus === 'loaded' && groups.length === 0) {
+        return (
+          <div>
+            <p className="phl">
+              <span className="mrs">🏆💯⭐️🌈{/* <- thar be emoji invisible in intellij */}</span>
+              <span>Congratulations! You’ve installed all of the skills published by Ellipsis.ai.</span>
+            </p>
+          </div>
+        );
+      } else if (this.props.publishedBehaviorGroupLoadStatus === 'loaded' && groups.length > 0) {
         return (
           <div>
 


### PR DESCRIPTION
Fix a bug where if there was a single installable skill, it wasn't shown, and add a message if you've installed all the things