### PR TITLE
A few tweaks to skills page search

### DIFF
--- a/app/assets/javascripts/behavior_list/index.jsx
+++ b/app/assets/javascripts/behavior_list/index.jsx
@@ -504,22 +504,20 @@ define(function(require) {
     },
 
     renderSearch: function() {
-      if (this.hasLocalBehaviorGroups()) {
-        return (
-          <div className="ptxl mbxl">
-            <div className="container container-c">
-              <div className="mhl">
-                <SearchInput
-                  placeholder="Search skills…"
-                  value={this.state.searchText}
-                  onChange={this.updateSearch}
-                  isSearching={this.props.isLoadingMatchingResults}
-                />
-              </div>
+      return (
+        <div className="ptxl mbxl">
+          <div className="container container-c">
+            <div className="mhl">
+              <SearchInput
+                placeholder="Search skills…"
+                value={this.state.searchText}
+                onChange={this.updateSearch}
+                isSearching={this.props.isLoadingMatchingResults}
+              />
             </div>
           </div>
-        );
-      }
+        </div>
+      );
     },
 
     render: function() {


### PR DESCRIPTION
- Always show the search box even when there are no local skills
- When there are local skills, always show the local section, even if none match the current search
