### PR TITLE
Put githubUrl property back on client-side behavior group property

### DIFF
--- a/app/assets/javascripts/models/behavior_group.jsx
+++ b/app/assets/javascripts/models/behavior_group.jsx
@@ -12,6 +12,7 @@ define(function(require) {
         name: { value: props.name, enumerable: true },
         icon: { value: props.icon, enumerable: true },
         description: { value: props.description, enumerable: true },
+        githubUrl: { value: props.githubUrl, enumerable: true },
         actionInputs: { value: props.actionInputs, enumerable: true },
         dataTypeInputs: { value: props.dataTypeInputs, enumerable: true },
         behaviorVersions: { value: props.behaviorVersions, enumerable: true },


### PR DESCRIPTION
- brings back the "View on Github" link