### PR TITLE
Explicitly disable unfurling regular links in Slack

### DIFF
--- a/app/utils/SlackMessageSender.scala
+++ b/app/utils/SlackMessageSender.scala
@@ -113,7 +113,7 @@ case class SlackMessageSender(
           channelToUse,
           segment,
           asUser = Some(true),
-          unfurlLinks = maybeShouldUnfurl,
+          unfurlLinks = Some(maybeShouldUnfurl.getOrElse(false)),
           unfurlMedia = Some(true),
           attachments = maybeAttachmentsForSegment,
           threadTs = maybeThreadTsToUse,


### PR DESCRIPTION
Slack seems to want unfurl links to be set explicitly to false to disable unfurling