### PR TITLE
Ensure code editor refreshes when becoming visible

### DIFF
--- a/app/assets/javascripts/behavior_editor/code_editor.jsx
+++ b/app/assets/javascripts/behavior_editor/code_editor.jsx
@@ -123,9 +123,15 @@ return React.createClass({
     cm.replaceSelection(spaces);
   },
 
+  refresh: function() {
+    this.refs.codemirror.refresh();
+  },
+
   render: function() {
     return (
-      <Codemirror value={this.props.value}
+      <Codemirror
+        ref="codemirror"
+        value={this.props.value}
         onChange={this.props.onChange}
         onCursorChange={this.props.onCursorChange}
         options={{

--- a/app/assets/javascripts/behavior_editor/index.jsx
+++ b/app/assets/javascripts/behavior_editor/index.jsx
@@ -667,6 +667,10 @@ const BehaviorEditor = React.createClass({
     }
   },
 
+  refreshCodeEditor: function() {
+    this.refs.codeEditor.refresh();
+  },
+
   loadVersions: function() {
     var url = jsRoutes.controllers.BehaviorEditorController.versionInfoFor(this.getBehaviorGroup().id).url;
     this.setState({
@@ -971,7 +975,10 @@ const BehaviorEditor = React.createClass({
       }
     });
     const updatedGroup = this.getBehaviorGroup().clone({ behaviorVersions: updatedBehaviorVersions });
-    this.updateGroupStateWith(updatedGroup, this.resetNotifications);
+    this.updateGroupStateWith(updatedGroup, () => {
+      this.resetNotifications();
+      this.refreshCodeEditor();
+    });
   },
 
   toggleCodeEditorLineWrapping: function() {
@@ -1511,6 +1518,7 @@ const BehaviorEditor = React.createClass({
 
         <div className="position-relative">
           <CodeEditor
+            ref="codeEditor"
             value={this.getBehaviorFunctionBody()}
             onChange={this.updateCode}
             onCursorChange={this.ensureCursorVisible}
@@ -2042,7 +2050,10 @@ const BehaviorEditor = React.createClass({
                   </div>
                 </Collapsible>
 
-                <Collapsible revealWhen={this.getSelectedBehavior().shouldRevealCodeEditor} animationDuration={0.5} animationDisabled={this.animationIsDisabled()}>
+                <Collapsible revealWhen={this.getSelectedBehavior().shouldRevealCodeEditor}
+                  animationDuration={0.5}
+                  animationDisabled={this.animationIsDisabled()}
+                >
 
                   <div className="container container-wide">
                     <div className="ptxl">

--- a/app/assets/javascripts/shared_ui/react-codemirror.jsx
+++ b/app/assets/javascripts/shared_ui/react-codemirror.jsx
@@ -102,6 +102,9 @@ return React.createClass({
       this.props.onChange(doc.getValue());
     }
   },
+  refresh: function() {
+    this.getCodeMirror().refresh();
+  },
   render: function render() {
     return (
       <div className={


### PR DESCRIPTION
When toggling the code editor, always force codemirror to refresh. This fixes #1469 where it appears to contain another behavior's code when first revealed on a new behavior.