### PR TITLE
Use currently selected ID to get the original copy of a behavior

### DIFF
--- a/app/assets/javascripts/behavior_editor/index.jsx
+++ b/app/assets/javascripts/behavior_editor/index.jsx
@@ -197,7 +197,7 @@ const BehaviorEditor = React.createClass({
   },
 
   getOriginalSelectedBehavior: function() {
-    return this.getSelectedBehaviorFor(this.props.group, this.props.selectedBehaviorId);
+    return this.getSelectedBehaviorFor(this.props.group, this.getSelectedBehaviorId());
   },
 
   getSelectedBehavior: function() {
@@ -1106,8 +1106,8 @@ const BehaviorEditor = React.createClass({
 
   isFinishedBehavior: function() {
     var originalSelectedBehavior = this.getOriginalSelectedBehavior();
-    var completedOriginal = !!(originalSelectedBehavior && (originalSelectedBehavior.functionBody || originalSelectedBehavior.responseTemplate.text));
-    return this.isExistingBehavior() && completedOriginal;
+    return !!(originalSelectedBehavior && !originalSelectedBehavior.isNewBehavior &&
+      (originalSelectedBehavior.functionBody || originalSelectedBehavior.responseTemplate.text));
   },
 
   isModified: function() {


### PR DESCRIPTION
When checking whether a behavior is finished, use the current selected behavior ID, not the page-load selected ID (which didn't make any sense).

Also check whether the original copy is new, rather than whether the current copy is new.

Resolves #1468 for real this time