### PR TITLE
Added a builtin-behavior to let us revoke all tokens for a particular oauth2 application

### DIFF
--- a/app/models/accounts/linkedoauth2token/LinkedOAuth2TokenService.scala
+++ b/app/models/accounts/linkedoauth2token/LinkedOAuth2TokenService.scala
@@ -1,5 +1,6 @@
 package models.accounts.linkedoauth2token
 
+import models.accounts.oauth2application.OAuth2Application
 import models.accounts.user.User
 import play.api.libs.ws.WSClient
 
@@ -10,5 +11,7 @@ trait LinkedOAuth2TokenService {
   def allForUser(user: User, ws: WSClient): Future[Seq[LinkedOAuth2Token]]
 
   def save(token: LinkedOAuth2Token): Future[LinkedOAuth2Token]
+
+  def deleteFor(application: OAuth2Application, user: User): Future[Boolean]
 
 }

--- a/app/models/accounts/linkedoauth2token/LinkedOAuth2TokenServiceImpl.scala
+++ b/app/models/accounts/linkedoauth2token/LinkedOAuth2TokenServiceImpl.scala
@@ -4,7 +4,7 @@ import java.time.OffsetDateTime
 import javax.inject.{Inject, Provider}
 
 import models.accounts.user.User
-import models.accounts.oauth2application.OAuth2ApplicationQueries
+import models.accounts.oauth2application.{OAuth2Application, OAuth2ApplicationQueries}
 import play.api.http.{HeaderNames, MimeTypes}
 import play.api.libs.ws.WSClient
 import play.api.mvc.Results
@@ -121,5 +121,8 @@ class LinkedOAuth2TokenServiceImpl @Inject() (
     dataService.run(action)
   }
 
-
+  def deleteFor(application: OAuth2Application, user: User): Future[Boolean] = {
+    val action = findQuery(user.id, application.id).delete.map(r => r > 0)
+    dataService.run(action)
+  }
 }

--- a/app/models/behaviors/builtins/BuiltinBehavior.scala
+++ b/app/models/behaviors/builtins/BuiltinBehavior.scala
@@ -32,6 +32,7 @@ object BuiltinBehavior {
   val unscheduleRegex = s"""(?i)^unschedule\\s+([`"'])(.*?)\\1\\s*$$""".r
   val resetBehaviorsRegex = """(?i)reset behaviors really really really""".r
   val setTimeZoneRegex = s"""(?i)^set default time\\s*zone to\\s(.*)$$""".r
+  val revokeAuthRegex = s"""(?i)^revoke\\s+all\\s+tokens\\s+for\\s+(.*)""".r
 
   def maybeFrom(event: Event, lambdaService: AWSLambdaService, dataService: DataService): Option[BuiltinBehavior] = {
     if (event.includesBotMention) {
@@ -57,6 +58,7 @@ object BuiltinBehavior {
         case unscheduleRegex(_, text) => Some(UnscheduleBehavior(text, event, lambdaService, dataService))
         case resetBehaviorsRegex() => Some(ResetBehaviorsBehavior(event, lambdaService, dataService))
         case setTimeZoneRegex(tzString) => Some(SetDefaultTimeZoneBehavior(tzString, event, lambdaService, dataService))
+        case revokeAuthRegex(appName) => Some(RevokeAuthBehavior(appName, event, lambdaService, dataService))
         case _ => None
       }
     } else {

--- a/app/models/behaviors/builtins/RevokeAuthBehavior.scala
+++ b/app/models/behaviors/builtins/RevokeAuthBehavior.scala
@@ -1,0 +1,38 @@
+package models.behaviors.builtins
+
+import akka.actor.ActorSystem
+import models.behaviors.events.Event
+import models.behaviors.{BotResult, SimpleTextResult}
+import services.{AWSLambdaService, DataService}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+case class RevokeAuthBehavior(
+                               appName: String,
+                               event: Event,
+                               lambdaService: AWSLambdaService,
+                               dataService: DataService
+                             ) extends BuiltinBehavior {
+
+  def result(implicit actorSystem: ActorSystem): Future[BotResult] = {
+    for {
+      maybeTeam <- dataService.teams.find(event.teamId)
+      user <- event.ensureUser(dataService)
+      maybeApplication <- maybeTeam.map { team =>
+        dataService.oauth2Applications.allFor(team)
+      }.getOrElse(Future.successful(Seq())).map(all => all.find(_.name.toLowerCase == appName.toLowerCase))
+      didDelete <- maybeApplication.map { app =>
+        dataService.linkedOAuth2Tokens.deleteFor(app, user)
+      }.getOrElse(Future.successful(false))
+    } yield {
+      val msg = if (didDelete) {
+        s"OK, I revoked all tokens for you for `$appName`"
+      } else {
+        s"I couldn't find any auth tokens for you for `$appName`"
+      }
+      SimpleTextResult(event, None, msg, forcePrivateResponse = false)
+    }
+  }
+
+}


### PR DESCRIPTION
- handy for demoing, etc
- triggered with e.g. `revoke all tokens for Google Calendar`