### PR TITLE
Meanwhile, a bug fix

### DIFF
--- a/app/controllers/APIController.scala
+++ b/app/controllers/APIController.scala
@@ -152,20 +152,20 @@ class APIController @Inject() (
 
   private def maybeIntroTextFor(isInvokedExternally: Boolean, event: Event, context: ApiMethodContext, isForInterruption: Boolean): Option[String] = {
     val greeting = if (isForInterruption) {
+      "Meanwhile, "
+    } else {
       s""":wave: Hi.
        |
        |""".stripMargin
-    } else {
-      "Meanwhile, "
     }
     if (isInvokedExternally) {
-      context.maybeSlackProfile.map { slackProfile =>
-        s"""$greeting<@${slackProfile.loginInfo.providerKey}> asked me to run `${event.messageText}`.
-         |
-         |───
-         |""".stripMargin
-      }
-    } else { None }
+      Some(s"""${greeting}I’ve been asked to run `${event.messageText}`.
+       |
+       |───
+       |""".stripMargin)
+    } else {
+      None
+    }
   }
 
   private def runBehaviorFor(maybeEvent: Option[Event], context: ApiMethodContext) = {


### PR DESCRIPTION
Fix accidentally inverted logic for using interruption text on API-requested actions, and get rid of the token owner's name for now.