### PR TITLE
Only add 'unhandledRejection' listener if there isn't one already

### DIFF
--- a/app/services/AWSLambdaServiceImpl.scala
+++ b/app/services/AWSLambdaServiceImpl.scala
@@ -280,10 +280,11 @@ class AWSLambdaServiceImpl @Inject() (
         |     callback(null, { "result": result === undefined ? null : result });
         |   };
         |   $CONTEXT_PARAM.error = function(err) { callback(err || "(No error message or an empty error message was provided.)"); };
-        |   process.on('unhandledRejection', function(reason, p) {
-        |     throw(reason);
-        |   });
-        |
+        |   if (process.listeners('unhandledRejection').length === 0) {
+        |     process.on('unhandledRejection', function(reason, p) {
+        |       throw(reason);
+        |     });
+        |   }
         |   ${awsCodeFor(maybeAwsConfig)}
         |   $CONTEXT_PARAM.accessTokens = {};
         |   ${accessTokensCodeFor(requiredOAuth2ApiConfigs)}


### PR DESCRIPTION
- this should stop those weird 'eventEmitter' warnings people are seeing (once their lambda functions are re-deployed)