### PR TITLE
ensure the existence of an ellipsis user at the beginning of the process of building user info

### DIFF
--- a/app/models/behaviors/testing/TestEvent.scala
+++ b/app/models/behaviors/testing/TestEvent.scala
@@ -47,7 +47,7 @@ case class TestEvent(
   }
 
   override def userInfo(ws: WSClient, dataService: DataService)(implicit actorSystem: ActorSystem): Future[UserInfo] = {
-    UserInfo.buildFor(Some(user), this, ws, dataService)
+    UserInfo.buildFor(user, this, ws, dataService)
   }
 
   override def ensureUser(dataService: DataService): Future[User] = {


### PR DESCRIPTION

- should get rid of weird errors if the first time a user runs a behavior is via a scheduled action