### PR TITLE
Introduce a <Button> component

### DIFF
--- a/app/assets/javascripts/form/button.jsx
+++ b/app/assets/javascripts/form/button.jsx
@@ -1,0 +1,41 @@
+define(function(require) {
+  const React = require('react');
+
+  class Button extends React.Component {
+    constructor(props) {
+      super(props);
+      this.onClick = this.onClick.bind(this);
+    }
+
+    onClick() {
+      // Strip the browser event object from the onClick handler
+      if (this.props.onClick) {
+        this.props.onClick();
+      }
+    }
+
+    render() {
+      return (
+        <button
+          className={
+            `button ${
+              this.props.className || ""
+            }`
+          }
+          type="button"
+          onClick={this.onClick}
+          disabled={this.props.disabled}
+        >{this.props.children}</button>
+      );
+    }
+  }
+
+  Button.propTypes = {
+    children: React.PropTypes.node.isRequired,
+    className: React.PropTypes.string,
+    disabled: React.PropTypes.bool,
+    onClick: React.PropTypes.func.isRequired
+  };
+
+  return Button;
+});


### PR DESCRIPTION
- avoids type="button"
- warns when no onClick handler is provided
- eventually, we can stop changing the default style of raw <button> elements, and then things like button-raw will be much simpler