### PR TITLE
Stop having redundant names on behavior versions and data type configs

### DIFF
--- a/app/json/BehaviorVersionData.scala
+++ b/app/json/BehaviorVersionData.scala
@@ -6,9 +6,13 @@ import json.Formatting._
 import models.IDs
 import models.accounts.user.User
 import models.behaviors.behaviorgroupversion.BehaviorGroupVersion
+import models.behaviors.datatypeconfig.BehaviorVersionForDataTypeSchema
+import models.behaviors.datatypefield.DataTypeFieldForSchema
+import models.behaviors.defaultstorageitem.GraphQLHelpers
 import models.team.Team
 import play.api.libs.json.Json
 import services.DataService
+import slick.dbio.DBIO
 import utils.NameFormatter
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -31,8 +35,18 @@ case class BehaviorVersionData(
                                 githubUrl: Option[String],
                                 knownEnvVarsUsed: Seq[String],
                                 createdAt: Option[OffsetDateTime]
-                                ) {
+                                ) extends BehaviorVersionForDataTypeSchema {
   val awsConfig: Option[AWSConfigData] = config.aws
+
+  lazy val typeName: String = name.getOrElse(GraphQLHelpers.fallbackTypeName)
+
+  def dataTypeFieldsAction(dataService: DataService): DBIO[Seq[DataTypeFieldForSchema]] = {
+    DBIO.successful(config.dataTypeConfig.map(_.fields).getOrElse(Seq()))
+  }
+
+  def dataTypeFields(dataService: DataService): Future[Seq[DataTypeFieldForSchema]] = {
+    dataService.run(dataTypeFieldsAction(dataService))
+  }
 
   def maybeExportName: Option[String] = {
     name.orElse(exportId)
@@ -105,7 +119,7 @@ object BehaviorVersionData {
 
   def maybeDataTypeConfigFor(isDataType: Boolean, maybeName: Option[String]): Option[DataTypeConfigData] = {
     if (isDataType) {
-      Some(DataTypeConfigData(maybeName, Seq(), None))
+      Some(DataTypeConfigData(Seq(), None))
     } else {
       None
     }
@@ -191,7 +205,7 @@ object BehaviorVersionData {
     val configWithDataTypeConfig = if (!config.isDataType || config.dataTypeConfig.isDefined) {
       config
     } else {
-      config.copy(dataTypeConfig = Some(DataTypeConfigData(config.name, Seq(), usesCode = Some(true))))
+      config.copy(dataTypeConfig = Some(DataTypeConfigData(Seq(), usesCode = Some(true))))
     }
     BehaviorVersionData.buildFor(
       None,

--- a/app/json/DataTypeConfigData.scala
+++ b/app/json/DataTypeConfigData.scala
@@ -1,22 +1,16 @@
 package json
 
 import export.BehaviorGroupExporter
-import models.behaviors.datatypeconfig.{DataTypeConfig, DataTypeConfigForSchema}
-import models.behaviors.datatypefield.DataTypeFieldForSchema
-import models.behaviors.defaultstorageitem.GraphQLHelpers
+import models.behaviors.datatypeconfig.DataTypeConfig
 import services.DataService
-import slick.dbio.DBIO
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 case class DataTypeConfigData(
-                               name: Option[String],
                                fields: Seq[DataTypeFieldData],
                                usesCode: Option[Boolean]
-                             ) extends DataTypeConfigForSchema {
-
-  lazy val typeName: String = name.getOrElse(GraphQLHelpers.fallbackTypeName)
+                             ) {
 
   def userDefinedFields: Seq[DataTypeFieldData] = fields.filterNot(_.isBuiltin)
 
@@ -44,14 +38,6 @@ case class DataTypeConfigData(
     }
   }
 
-  def dataTypeFieldsAction(dataService: DataService): DBIO[Seq[DataTypeFieldForSchema]] = {
-    DBIO.successful(fields)
-  }
-
-  def dataTypeFields(dataService: DataService): Future[Seq[DataTypeFieldForSchema]] = {
-    Future.successful(fields)
-  }
-
 }
 
 object DataTypeConfigData {
@@ -68,7 +54,7 @@ object DataTypeConfigData {
       val fieldData = withFieldType.map { case(field, fieldTypeData) =>
         DataTypeFieldData(Some(field.id), Some(field.fieldId), None, field.name, Some(fieldTypeData), field.isLabel)
       }
-      DataTypeConfigData(config.maybeName, fieldData, config.maybeUsesCode)
+      DataTypeConfigData(fieldData, config.maybeUsesCode)
     }
   }
 }

--- a/app/models/behaviors/behaviorparameter/BehaviorParameterType.scala
+++ b/app/models/behaviors/behaviorparameter/BehaviorParameterType.scala
@@ -200,8 +200,8 @@ case class BehaviorBackedDataType(dataTypeConfig: DataTypeConfig) extends Behavi
   override val exportId: String = behaviorVersion.behavior.maybeExportId.getOrElse(id)
   val name = behaviorVersion.maybeName.getOrElse("Unnamed data type")
 
-  val outputName: String = dataTypeConfig.outputName
-  override lazy val inputName: String = dataTypeConfig.inputName
+  val outputName: String = behaviorVersion.outputName
+  override lazy val inputName: String = behaviorVersion.inputName
 
   val isBuiltIn: Boolean = false
 
@@ -395,9 +395,9 @@ case class BehaviorBackedDataType(dataTypeConfig: DataTypeConfig) extends Behavi
             throw new RuntimeException("Need a valid label field")
           }
         }.getOrElse("{}"))
-        query <- dataTypeConfig.outputFieldNamesAction(context.dataService).map { fieldStr =>
+        query <- behaviorVersion.outputFieldNamesAction(context.dataService).map { fieldStr =>
           s"""{
-             |  ${dataTypeConfig.listName}(filter: $filter) {
+             |  ${behaviorVersion.listName}(filter: $filter) {
              |  $fieldStr
              |  }
              |}

--- a/app/models/behaviors/datatypeconfig/BehaviorVersionForDataTypeSchema.scala
+++ b/app/models/behaviors/datatypeconfig/BehaviorVersionForDataTypeSchema.scala
@@ -8,7 +8,7 @@ import slick.dbio.DBIO
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-trait DataTypeConfigForSchema {
+trait BehaviorVersionForDataTypeSchema {
 
   val typeName: String
   lazy val fieldName = GraphQLHelpers.formatFieldName(typeName)

--- a/app/models/behaviors/datatypeconfig/DataTypeConfig.scala
+++ b/app/models/behaviors/datatypeconfig/DataTypeConfig.scala
@@ -1,31 +1,14 @@
 package models.behaviors.datatypeconfig
 
 import models.behaviors.behaviorversion.BehaviorVersion
-import models.behaviors.datatypefield.DataTypeFieldForSchema
-import models.behaviors.defaultstorageitem.GraphQLHelpers
-import services.DataService
-import slick.dbio.DBIO
-
-import scala.concurrent.Future
 
 case class DataTypeConfig(
                           id: String,
                           maybeUsesCode: Option[Boolean],
                           behaviorVersion: BehaviorVersion
-                        ) extends DataTypeConfigForSchema {
-
-  lazy val maybeName = behaviorVersion.maybeName
-  lazy val typeName = maybeName.getOrElse(GraphQLHelpers.fallbackTypeName)
+                        ) {
 
   def usesCode: Boolean = maybeUsesCode.isEmpty || maybeUsesCode.contains(true)
-
-  def dataTypeFieldsAction(dataService: DataService): DBIO[Seq[DataTypeFieldForSchema]] = {
-    dataService.dataTypeFields.allForAction(this)
-  }
-
-  def dataTypeFields(dataService: DataService): Future[Seq[DataTypeFieldForSchema]] = {
-    dataService.run(dataTypeFieldsAction(dataService))
-  }
 
   def toRaw: RawDataTypeConfig = RawDataTypeConfig(id, maybeUsesCode, behaviorVersion.id)
 }


### PR DESCRIPTION
- required some restructuring of graphql schema building