### PR TITLE
More reserved words that can't be used as identifiers

### DIFF
--- a/app/assets/javascripts/lib/formatter.jsx
+++ b/app/assets/javascripts/lib/formatter.jsx
@@ -3,10 +3,26 @@ define(function(require) {
   var ONE_WEEK_IN_MS = 1000 * 60 * 60 * 24 * 7;
 
   const RESERVED_WORDS = Object.freeze([
+    // ECMAScript 2015 reserved words:
     'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger', 'default',
     'delete', 'do', 'else', 'export', 'extends', 'finally', 'for', 'function',
     'if', 'import', 'in', 'instanceof', 'new', 'return', 'super', 'switch',
-    'this', 'throw', 'try', 'typeof', 'var', 'void', 'while', 'with', 'yield'
+    'this', 'throw', 'try', 'typeof', 'var', 'void', 'while', 'with', 'yield',
+
+    // ECMAScript future reserved words:
+    'enum', 'implements', 'interface', 'let', 'package', 'private', 'protected',
+    'public', 'static',
+
+    // Module reserved words:
+    'await',
+
+    // Old future reserved words:
+    'abstract', 'boolean', 'byte', 'char', 'double', 'final', 'float', 'goto',
+    'int', 'long', 'native', 'short', 'synchronized', 'throws', 'transient',
+    'volatile',
+
+    // Reserved literals:
+    'null', 'true', 'false'
   ]);
 
   function matchesReservedWord(name) {

--- a/test/formatter_spec.js
+++ b/test/formatter_spec.js
@@ -52,14 +52,17 @@ describe("Formatter", () => {
 
     it("adds an underscore prefix reserved words", () => {
       expect(Formatter.formatNameForCode("for")).toEqual("_for");
+      expect(Formatter.formatNameForCode("null")).toEqual("_null");
     });
 
     it("removes an underscore prefix when one more character is typed after a reserved word", () => {
       expect(Formatter.formatNameForCode("_form")).toEqual("form");
+      expect(Formatter.formatNameForCode("_nulls")).toEqual("nulls");
     });
 
     it("preserves underscore prefixes for strings that start with a reserved word with 2 or more characters", () => {
       expect(Formatter.formatNameForCode("_format")).toEqual("_format");
+      expect(Formatter.formatNameForCode("_nulled")).toEqual("_nulled");
     });
 
     it("strips more than a single underscore prefix", () => {


### PR DESCRIPTION
Greatly expand the list of reserved/banned words in identifiers to include things like true, false, null, etc, and everything else documented here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords