### PR TITLE
Fix missing input message in testing tool

### DIFF
--- a/app/assets/javascripts/behavior_editor/behavior_tester_invocation_result.jsx
+++ b/app/assets/javascripts/behavior_editor/behavior_tester_invocation_result.jsx
@@ -35,7 +35,7 @@ define(function(require) {
     missingInputs() {
       const missingInputNames = this.props.result.missingInputNames;
       return (
-        <div className="display-overflow-scroll border border-pink bg-white pas">
+        <div>
           {missingInputNames.length === 1 ? (
             <span>
               Ellipsis will ask the user for a value for the input <code className="type-bold mlxs">{missingInputNames[0]}</code>.
@@ -53,7 +53,7 @@ define(function(require) {
     missingUserEnvVars() {
       const missingUserEnvVars = this.props.result.missingUserEnvVars;
       return (
-        <div className="display-overflow-scroll border border-pink bg-white pas">
+        <div>
           {missingUserEnvVars.length === 1 ? (
             <span>
               If, like you, the user hasn't yet set a value for the environment variable <code className="type-bold">{missingUserEnvVars[0]}</code>, Ellipsis will ask for one.

--- a/app/models/behaviors/testing/InvocationTestReport.scala
+++ b/app/models/behaviors/testing/InvocationTestReport.scala
@@ -9,7 +9,7 @@ import play.api.libs.json._
 case class ResultOutput(kind: String, fullText: String)
 
 case class InvocationTestReportOutput(
-                                      missingParamNames: Seq[String],
+                                      missingInputNames: Seq[String],
                                       missingSimpleTokens: Seq[String],
                                       missingUserEnvVars: Set[String],
                                       result: Option[ResultOutput]


### PR DESCRIPTION
Match up the invocation test report missing inputs/params with the property name we're expecting in JS

Fixes #1779 