### PR TITLE
If there's a refresh token and no expiration time, just ensure one 1h in the future

### DIFF
--- a/app/models/accounts/linkedoauth2token/LinkedOAuth2Token.scala
+++ b/app/models/accounts/linkedoauth2token/LinkedOAuth2Token.scala
@@ -34,6 +34,13 @@ case class LinkedOAuth2Token(
 
   def isExpiredOrExpiresSoon: Boolean = maybeExpirationTime.exists(_.isBefore(OffsetDateTime.now.plusMinutes(1)))
 
+  def copyWithExpirationTimeIfRefreshToken: LinkedOAuth2Token = {
+    val maybeEnsuredExpirationTime = maybeExpirationTime.orElse(maybeRefreshToken.map { _ =>
+      OffsetDateTime.now.plusHours(1)
+    })
+    copy(maybeExpirationTime = maybeEnsuredExpirationTime)
+  }
+
   def toRaw: RawLinkedOAuth2Token = RawLinkedOAuth2Token(
     accessToken,
     maybeTokenType,

--- a/app/models/accounts/linkedoauth2token/LinkedOAuth2TokenServiceImpl.scala
+++ b/app/models/accounts/linkedoauth2token/LinkedOAuth2TokenServiceImpl.scala
@@ -113,7 +113,8 @@ class LinkedOAuth2TokenServiceImpl @Inject() (
   }
   val findQuery = Compiled(uncompiledFindQuery _)
 
-  def saveAction(token: LinkedOAuth2Token): DBIO[LinkedOAuth2Token] = {
+  def saveAction(tokenWithoutExpirationTimeEnsured: LinkedOAuth2Token): DBIO[LinkedOAuth2Token] = {
+    val token = tokenWithoutExpirationTimeEnsured.copyWithExpirationTimeIfRefreshToken
     val query = findQuery(token.userId, token.application.id)
     val raw = token.toRaw
     query.result.headOption.flatMap {


### PR DESCRIPTION
- will be wrong if there's an api that expires quicker and doesn't send us expires_in, but :shrug: for now