### PR TITLE
Updated our OAuth2 flow to work around some unexpected aspects of the Adroll implementation:

### DIFF
--- a/app/models/accounts/linkedoauth2token/LinkedOAuth2Token.scala
+++ b/app/models/accounts/linkedoauth2token/LinkedOAuth2Token.scala
@@ -4,6 +4,7 @@ import java.time.OffsetDateTime
 
 import com.mohiva.play.silhouette.impl.providers.OAuth2Info
 import models.accounts.oauth2application.OAuth2Application
+import play.api.libs.json.{JsValue, Json}
 
 case class LinkedOAuth2Token(
                               accessToken: String,
@@ -41,6 +42,16 @@ case class LinkedOAuth2Token(
     copy(maybeExpirationTime = maybeEnsuredExpirationTime)
   }
 
+  def copyFrom(info: LinkedOAuth2TokenInfo): LinkedOAuth2Token = {
+    copy(
+      accessToken = info.accessToken,
+      maybeScopeGranted = info.maybeScopeGranted.orElse(maybeScopeGranted),
+      maybeExpirationTime = info.maybeExpirationTime,
+      maybeTokenType = info.maybeTokenType.orElse(maybeTokenType),
+      maybeRefreshToken = info.maybeRefreshToken.orElse(maybeRefreshToken)
+    )
+  }
+
   def toRaw: RawLinkedOAuth2Token = RawLinkedOAuth2Token(
     accessToken,
     maybeTokenType,
@@ -50,5 +61,45 @@ case class LinkedOAuth2Token(
     userId,
     application.id
   )
+
+}
+
+case class LinkedOAuth2TokenInfo(
+                                  accessToken: String,
+                                  maybeTokenType: Option[String],
+                                  maybeExpirationTime: Option[OffsetDateTime],
+                                  maybeRefreshToken: Option[String],
+                                  maybeScopeGranted: Option[String]
+                                )
+
+object LinkedOAuth2TokenInfo {
+
+  def maybeFrom(json: JsValue): Option[LinkedOAuth2TokenInfo] = {
+    (json \ "access_token").asOpt[String].map { accessToken =>
+      val maybeTokenType = (json \ "token_type").asOpt[String]
+      val maybeScopeGranted = (json \ "scope").asOpt[String]
+      val expiresInLookup = (json \ "expires_in")
+      val maybeExpiresInSeconds = expiresInLookup.asOpt[Int].orElse {
+        expiresInLookup.asOpt[String].flatMap { str =>
+          try {
+            Some(str.toInt)
+          } catch {
+            case e: NumberFormatException => None
+          }
+        }
+      }
+      val maybeExpirationTime = maybeExpiresInSeconds.map { seconds =>
+        OffsetDateTime.now.plusSeconds(seconds)
+      }
+      val maybeRefreshToken = (json \ "refresh_token").asOpt[String]
+      LinkedOAuth2TokenInfo(
+        accessToken,
+        maybeTokenType,
+        maybeExpirationTime,
+        maybeRefreshToken,
+        maybeScopeGranted
+      )
+    }
+  }
 
 }

--- a/app/models/behaviors/behaviorversion/BehaviorVersionServiceImpl.scala
+++ b/app/models/behaviors/behaviorversion/BehaviorVersionServiceImpl.scala
@@ -18,7 +18,6 @@ import models.behaviors.config.requiredsimpletokenapi.RequiredSimpleTokenApi
 import models.behaviors.conversations.conversation.Conversation
 import models.behaviors.events.Event
 import models.team.Team
-import play.api.libs.json.JsValue
 import play.api.libs.ws.WSClient
 import play.api.{Configuration, Logger}
 import services.{AWSLambdaService, CacheService, DataService}

--- a/app/models/behaviors/conversations/InvokeBehaviorConversation.scala
+++ b/app/models/behaviors/conversations/InvokeBehaviorConversation.scala
@@ -9,7 +9,6 @@ import models.behaviors.behaviorversion.BehaviorVersion
 import models.behaviors.conversations.conversation.Conversation
 import models.behaviors.events.{Event, SlackMessageEvent}
 import models.behaviors.triggers.messagetrigger.MessageTrigger
-import models.behaviors.{BehaviorResponse, BotResult}
 import services.{DataService, DefaultServices}
 import slick.dbio.DBIO
 import utils.SlackMessageReactionHandler


### PR DESCRIPTION
- they give us back a new refresh_token every time we use the refresh_token to get a new access_token
- they give us back expires_in as a string instead of a number