### PR TITLE
If there's no previous function when zipping a skill for deploy, always install npm modules

### DIFF
--- a/app/services/AWSLambdaServiceImpl.scala
+++ b/app/services/AWSLambdaServiceImpl.scala
@@ -359,7 +359,7 @@ class AWSLambdaServiceImpl @Inject() (
     }
 
     val requiredModules = requiredModulesIn(functionBody, libraries, includeLibraryRequires = true)
-    val canUseCopyModules = maybePreviousFunctionInfo.forall { previousFunctionInfo =>
+    val canUseCopyModules = maybePreviousFunctionInfo.exists { previousFunctionInfo =>
       if (previousFunctionInfo.canCopyModules(requiredModules)) {
         previousFunctionInfo.copyModulesInto(dirName)
         true


### PR DESCRIPTION
Fixes #1797 