### PR TITLE
Assets cdm fix

### DIFF
--- a/deploy/circleci_build
+++ b/deploy/circleci_build
@@ -175,7 +175,6 @@ else
 fi
 
 
-
 printf "\n\n${GREEN}Creating new app version ...${PLAIN}\n";
 printf "_____________________________________________________ \n";
 aws --profile $AWS_ELLIPSIS_PROFILE elasticbeanstalk create-application-version \


### PR DESCRIPTION
Cleaning up the circle_build script after having fixed the CloundFront distribution configuration