### PR TITLE
Wrap certain Slack formatting characters after Markdown parsing so they don't ruin formatting

### DIFF
--- a/app/models/behaviors/templates/SlackRenderer.scala
+++ b/app/models/behaviors/templates/SlackRenderer.scala
@@ -72,8 +72,9 @@ class SlackRenderer(stringBuilder: StringBuilder) extends AbstractVisitor {
   }
 
   override def visit(heading: Heading) {
+    stringBuilder.append("*")
     visitChildren(heading)
-    stringBuilder.append("\r\r")
+    stringBuilder.append("*\r\r")
   }
 
   override def visit(thematicBreak: ThematicBreak) {
@@ -162,7 +163,10 @@ class SlackRenderer(stringBuilder: StringBuilder) extends AbstractVisitor {
   }
 
   override def visit(text: Text) {
-    stringBuilder.append(text.getLiteral)
+    /* HACK: any leftover formatting characters not parsed as Markdown get
+       surrounded by soft hyphens to disable accidental formatting in Slack */
+    val safeText = text.getLiteral.replaceAll("[*_`~]", "\u00AD$0\u00AD")
+    stringBuilder.append(safeText)
     visitChildren(text)
   }
 

--- a/test/SlackMessageFormatterSpec.scala
+++ b/test/SlackMessageFormatterSpec.scala
@@ -20,6 +20,10 @@ class SlackMessageFormatterSpec extends PlaySpec {
       format("my balogna has a first name\nit's O-S-C-A-R") mustBe "my balogna has a first name\rit's O-S-C-A-R"
     }
 
+    "insert soft hyphens around special characters that aren't used to format" in {
+      format("__this is `bold with~ special* char_acters__") mustBe "*this is \u00AD`\u00ADbold with\u00AD~\u00AD special\u00AD*\u00AD char\u00AD_\u00ADacters*"
+    }
+
   }
 
 }


### PR DESCRIPTION
Also rewrote some of the question preamble to tell you how to get out and added support for Markdown headings.

Fixes #1946 