### PR TITLE
Don't wrap formatting characters in the middle of a word

### DIFF
--- a/app/models/behaviors/templates/SlackRenderer.scala
+++ b/app/models/behaviors/templates/SlackRenderer.scala
@@ -165,7 +165,9 @@ class SlackRenderer(stringBuilder: StringBuilder) extends AbstractVisitor {
   override def visit(text: Text) {
     /* HACK: any leftover formatting characters not parsed as Markdown get
        surrounded by soft hyphens to disable accidental formatting in Slack */
-    val safeText = text.getLiteral.replaceAll("[*_`~]", "\u00AD$0\u00AD")
+    val safeText = text.getLiteral.
+      replaceAll("""(\S)([*_`~])(\s|$)""", "$1\u00AD$2\u00AD$3").
+      replaceAll("""(\s|^)([*_`~])(\S)""", "$1\u00AD$2\u00AD$3")
     stringBuilder.append(safeText)
     visitChildren(text)
   }

--- a/test/SlackMessageFormatterSpec.scala
+++ b/test/SlackMessageFormatterSpec.scala
@@ -20,8 +20,8 @@ class SlackMessageFormatterSpec extends PlaySpec {
       format("my balogna has a first name\nit's O-S-C-A-R") mustBe "my balogna has a first name\rit's O-S-C-A-R"
     }
 
-    "insert soft hyphens around special characters that aren't used to format" in {
-      format("__this is `bold with~ special* char_acters__") mustBe "*this is \u00AD`\u00ADbold with\u00AD~\u00AD special\u00AD*\u00AD char\u00AD_\u00ADacters*"
+    "insert soft hyphens around dangling special characters that aren't used to format" in {
+      format("__this is `bold with~ special char_acters*__") mustBe "*this is \u00AD`\u00ADbold with\u00AD~\u00AD special char_acters\u00AD*\u00AD*"
     }
 
   }


### PR DESCRIPTION
This ensures that stuff like `:slightly_frowning_face:` still works. 🤦‍♂️ 