### PR TITLE
Looks like, for play, we want this config to avoid those 400s for HTTP 1.0 requests with no host header

### DIFF
--- a/conf/akka.conf
+++ b/conf/akka.conf
@@ -1,3 +1,4 @@
 akka.http.client.parsing.illegal-header-warnings=false
 akka.http.server.parsing.illegal-header-warnings=false
 akka.http.server.default-host-header=${?BASE_HOST}
+play.server.akka.default-host-header=${?BASE_HOST}


### PR DESCRIPTION
With this config:

```
$ curl http://localhost:9000/sign_in_with_slack --header 'Host:' --http1.0 --head
HTTP/1.0 200 OK
```

Without:

```
$ curl http://localhost:9000/sign_in_with_slack --header 'Host:' --http1.0
HTTP/1.1 400 Bad Request
Request is missing required `Host` header
```
