### PR TITLE
Make the invocation token expiry be dynamically based on the aws lambda function timeout

### DIFF
--- a/app/models/behaviors/invocationtoken/InvocationToken.scala
+++ b/app/models/behaviors/invocationtoken/InvocationToken.scala
@@ -8,7 +8,4 @@ case class InvocationToken(
                             behaviorId: String,
                             maybeScheduledMessageId: Option[String],
                             createdAt: OffsetDateTime
-                          ) {
-  // Ellipsis's function time out is 10 seconds, but there can be a delay in starting, so we allow an extra 5
-  def isExpired: Boolean = createdAt.isBefore(OffsetDateTime.now.minusSeconds(15))
-}
+                          )

--- a/app/models/behaviors/invocationtoken/InvocationTokenServiceImpl.scala
+++ b/app/models/behaviors/invocationtoken/InvocationTokenServiceImpl.scala
@@ -5,7 +5,7 @@ import javax.inject.Inject
 
 import com.google.inject.Provider
 import models.IDs
-import services.DataService
+import services.{AWSLambdaService, DataService}
 import drivers.SlickPostgresDriver.api._
 import models.accounts.user.User
 import models.behaviors.behavior.Behavior
@@ -26,10 +26,12 @@ class InvocationTokensTable(tag: Tag) extends Table[InvocationToken](tag, "invoc
 
 class InvocationTokenServiceImpl @Inject() (
                                   dataServiceProvider: Provider[DataService],
+                                  lambdaServiceProvider: Provider[AWSLambdaService],
                                   implicit val ec: ExecutionContext
                                 ) extends InvocationTokenService {
 
   def dataService = dataServiceProvider.get
+  def lambdaService = lambdaServiceProvider.get
 
   val all = TableQuery[InvocationTokensTable]
 
@@ -42,9 +44,14 @@ class InvocationTokenServiceImpl @Inject() (
     dataService.run(findQueryFor(id).result.map(_.headOption))
   }
 
+  def isExpired(token: InvocationToken): Boolean = {
+    // there can be a delay in starting, so we allow an extra 5 seconds
+    token.createdAt.isBefore(OffsetDateTime.now.minusSeconds(lambdaService.invocationTimeoutSeconds + 5))
+  }
+
   def findNotExpired(id: String): Future[Option[InvocationToken]] = {
     find(id).map { maybeToken =>
-      maybeToken.filterNot(_.isExpired)
+      maybeToken.filterNot(isExpired)
     }
   }
 

--- a/app/services/AWSLambdaService.scala
+++ b/app/services/AWSLambdaService.scala
@@ -30,6 +30,8 @@ trait AWSLambdaService extends AWSService {
 
   val configuration: Configuration
 
+  val invocationTimeoutSeconds: Int = configuration.get[Int]("aws.lambda.timeoutSeconds")
+
   val client: AWSLambdaAsync
 
   def listBehaviorGroupFunctionNames: Future[Seq[String]]

--- a/app/services/AWSLambdaServiceImpl.scala
+++ b/app/services/AWSLambdaServiceImpl.scala
@@ -66,8 +66,6 @@ class AWSLambdaServiceImpl @Inject() (
 
   val apiBaseUrl: String = configuration.get[String](s"application.$API_BASE_URL_KEY")
 
-  val invocationTimeoutSeconds: Int = configuration.get[Int]("aws.lambda.timeoutSeconds")
-
   val logSubscriptionsEnabled: Boolean = configuration.get[Boolean]("aws.logSubscriptions.enabled")
   val logSubscriptionsLambdaFunctionName: String = configuration.get[String]("aws.logSubscriptions.lambdaFunctionName")
   val logSubscriptionsFilterPattern: String = configuration.get[String]("aws.logSubscriptions.filterPattern")


### PR DESCRIPTION
- we increased the latter but forgot about the former