### PR TITLE
Don't try cache by default in github fetcher

### DIFF
--- a/app/utils/github/GithubFetcher.scala
+++ b/app/utils/github/GithubFetcher.scala
@@ -31,7 +31,7 @@ trait GithubFetcher[T] {
 
   val cacheKey: String
   val cacheTimeout: Duration = config.get[Int]("github.cacheTimeoutSeconds").seconds
-  val shouldTryCache: Boolean = true
+  val shouldTryCache: Boolean = false
 
   def query: String
 


### PR DESCRIPTION
- continue using it for published skills case