### PR TITLE
Fix security loopholes with target="_blank" and change lint rule to be strict

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -130,8 +130,6 @@ rules:
     - warn
   react/no-find-dom-node:
     - off
-  react/jsx-no-target-blank:
-    - warn
   react/no-unescaped-entities:
     - warn
 

--- a/app/assets/javascripts/behavior_editor/response_template_help.jsx
+++ b/app/assets/javascripts/behavior_editor/response_template_help.jsx
@@ -84,7 +84,7 @@ Something went wrong.
       >
         <p>
           <span>Write a response for Ellipsis to send when the action is complete. You can use </span>
-          <span><a href="http://commonmark.org/help/" target="_blank">Markdown</a> formatting, if desired.</span>
+          <span><a href="http://commonmark.org/help/" target="_blank" rel="noreferrer noopener">Markdown</a> formatting, if desired.</span>
         </p>
 
         <p>Use the following methods to insert data and add basic logic:</p>

--- a/app/assets/javascripts/behavior_editor/trigger_help.jsx
+++ b/app/assets/javascripts/behavior_editor/trigger_help.jsx
@@ -26,7 +26,7 @@ return React.createClass({
           <li>
             <p>
               <span><b>Regular expression</b> — Interpret a trigger as a </span>
-              <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" target="_blank">regular expression pattern</a>
+              <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html" target="_blank" rel="noreferrer noopener">regular expression pattern</a>
               <span>.</span>
             </p>
           </li>

--- a/app/assets/javascripts/notifications/aws_unused.jsx
+++ b/app/assets/javascripts/notifications/aws_unused.jsx
@@ -14,7 +14,7 @@ define(function(require) {
         <span>
           <span>Use <code className="box-code-example mhxs">{this.props.details[0].code}</code> in your </span>
           <span>function to access methods and properties of the </span>
-          <span><a href="http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-intro.html" target="_blank">AWS SDK</a>.</span>
+          <span><a href="http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-intro.html" target="_blank" rel="noreferrer noopener">AWS SDK</a>.</span>
         </span>
       );
     }


### PR DESCRIPTION
TIL: `target="_blank"` is bad without `rel="noopener"`: https://mathiasbynens.github.io/rel-noopener/