### PR TITLE
Invert what is considered "added" or "removed"

### DIFF
--- a/app/assets/javascripts/models/diffs.jsx
+++ b/app/assets/javascripts/models/diffs.jsx
@@ -196,17 +196,17 @@ define(function(require) {
 
   }
 
-  function diffsFor<T: Diffable, P: Diffable>(firstItems: Array<T>, secondItems: Array<T>, parents?: { mine: P, other: P }): Array<Diff> {
-    const myIds = firstItems.map(ea => ea.getIdForDiff());
-    const otherIds = secondItems.map(ea => ea.getIdForDiff());
+  function diffsFor<T: Diffable, P: Diffable>(originalItems: Array<T>, newItems: Array<T>, parents?: { mine: P, other: P }): Array<Diff> {
+    const originalIds = originalItems.map(ea => ea.getIdForDiff());
+    const newIds = newItems.map(ea => ea.getIdForDiff());
 
-    const modifiedIds = myIds.filter(ea => otherIds.indexOf(ea) >= 0);
-    const addedIds = myIds.filter(ea => otherIds.indexOf(ea) === -1);
-    const removedIds = otherIds.filter(ea => myIds.indexOf(ea) === -1);
+    const modifiedIds = originalIds.filter(ea => newIds.indexOf(ea) >= 0);
+    const addedIds = newIds.filter(ea => originalIds.indexOf(ea) === -1);
+    const removedIds = originalIds.filter(ea => newIds.indexOf(ea) === -1);
 
     const added: Array<Diff> = [];
     addedIds.forEach(eaId => {
-      const item = firstItems.find(ea => ea.getIdForDiff() === eaId);
+      const item = newItems.find(ea => ea.getIdForDiff() === eaId);
       if (item) {
         added.push(new AddedDiff(item));
       }
@@ -214,7 +214,7 @@ define(function(require) {
 
     const removed: Array<Diff> = [];
     removedIds.forEach(eaId => {
-      const item = secondItems.find(ea => ea.getIdForDiff() === eaId);
+      const item = originalItems.find(ea => ea.getIdForDiff() === eaId);
       if (item) {
         removed.push(new RemovedDiff(item));
       }
@@ -222,10 +222,10 @@ define(function(require) {
 
     const modified: Array<Diff> = [];
     modifiedIds.forEach(eaId => {
-      const firstItem = firstItems.find(ea => ea.getIdForDiff() === eaId);
-      const secondItem = secondItems.find(ea => ea.getIdForDiff() === eaId);
-      if (firstItem && secondItem) {
-        const diff = (firstItem: Object).maybeDiffFor(secondItem, parents); // TODO: figure out how to add this method to Diffable
+      const originalItem = originalItems.find(ea => ea.getIdForDiff() === eaId);
+      const newItem = newItems.find(ea => ea.getIdForDiff() === eaId);
+      if (originalItem && newItem) {
+        const diff = (originalItem: Object).maybeDiffFor(newItem, parents); // TODO: figure out how to add this method to Diffable
         if (diff) {
           modified.push(diff);
         }

--- a/test/assets/javascripts/diffs/diff_spec.js
+++ b/test/assets/javascripts/diffs/diff_spec.js
@@ -304,17 +304,17 @@ describe('BehaviorGroupVersion', () => {
               {
                 "item": {
                   "caseSensitive": false,
-                  "isRegex": false,
+                  "isRegex": true,
                   "requiresMention": false,
-                  "text": "C"
+                  "text": ".+"
                 }
               },
               {
                 "item": {
                   "caseSensitive": false,
-                  "isRegex": true,
+                  "isRegex": false,
                   "requiresMention": false,
-                  "text": ".+"
+                  "text": "C"
                 }
               },
               {
@@ -441,8 +441,8 @@ describe('BehaviorGroupVersion', () => {
       expect(diffText).toContain("Description: [+A description]");
       expect(diffText).toContain("Response template: A[+nother] template");
       expect(diffText).toContain("Code: use strict;[+ // so strict]");
-      expect(diffText).toContain("Added trigger \"C\"");
-      expect(diffText).toContain("Removed trigger \".+\"");
+      expect(diffText).toContain("Removed trigger \"C\"");
+      expect(diffText).toContain("Added trigger \".+\"");
       expect(diffText).toContain("Modified trigger \"B\":\nRequire bot mention: changed to true");
       expect(diffText).toContain("Modified library \"some-lib\":");
       expect(diffText).toContain("Name: some-lib[+-revised]");


### PR DESCRIPTION
When calculating diffs, consider items present in the second list and not in the first as "added", instead of considering them "removed".

So diffsFor([A, B, C], [B, C, D]) would say that A is removed and D is added. (It previously said the opposite.)

I believe this matches the logic for text diffs, where text in the second item but not in the first is considered "added".