### PR TITLE
Make it OK for code-backed data types to just return an array of strings

### DIFF
--- a/app/assets/javascripts/behavior_editor/data_type_tester.jsx
+++ b/app/assets/javascripts/behavior_editor/data_type_tester.jsx
@@ -35,7 +35,14 @@ define(function(require) {
 
     getParsedResponse: function(result) {
       try {
-        return JSON.parse(result.responseText);
+        const parsed = JSON.parse(result.responseText);
+        if (parsed.every(ea => typeof ea === "string")) {
+          return parsed.map(ea => {
+            return { label: ea, id: ea };
+          });
+        } else {
+          return parsed;
+        }
       } catch(e) {
         return null;
       }

--- a/app/models/behaviors/behaviorparameter/BehaviorParameterType.scala
+++ b/app/models/behaviors/behaviorparameter/BehaviorParameterType.scala
@@ -460,7 +460,12 @@ case class BehaviorBackedDataType(dataTypeConfig: DataTypeConfig) extends Behavi
           extractValidValueFrom(ea)
         }
       }
-      case _: JsError => Seq()
+      case _: JsError => {
+        result.result.validate[Seq[String]] match {
+          case JsSuccess(strings, _) => strings.map { ea => ValidValue(ea, ea, Map()) }
+          case _: JsError => Seq()
+        }
+      }
     }
   }
 


### PR DESCRIPTION
`[ "foo", "bar" ]` will be interpreted as `[ { label: "foo", id: "foo" }, { label: "bar", id: "bar" }]`