### PR TITLE
Fix some bugs with calendar event formatting

### DIFF
--- a/npm_modules/ellipsis-cal-date-format/__tests__/ellipsis_cal_date_format_spec.js
+++ b/npm_modules/ellipsis-cal-date-format/__tests__/ellipsis_cal_date_format_spec.js
@@ -287,4 +287,23 @@ describe("Formatter", () => {
       ].join(" "));
     });
   });
+
+  describe("summaryLink", () => {
+    it("creates an escaped link with the summary text and attendees", () => {
+      const event = {
+        summary: '[Meeting <> Time]',
+        htmlLink: 'https://www.google.com/calendar/event',
+        attendees: [{
+          email: "joe@whitehouse.gov"
+        }, {
+          email: "barack@whitehouse.gov",
+          displayName: "Obama"
+        }, {
+          email: "valerie@whitehouse.gov",
+          self: true
+        }]
+      };
+      expect(Formatter.summaryLink(event)).toBe("[\\[Meeting \\<\\> Time\\] - joe@whitehouse.gov, Obama](https://www.google.com/calendar/event)");
+    });
+  });
 });

--- a/npm_modules/ellipsis-cal-date-format/index.js
+++ b/npm_modules/ellipsis-cal-date-format/index.js
@@ -27,7 +27,7 @@ const EventFormatter = {
   formatAttendeesFor(event) {
     const attendees = event.attendees || [];
     const attendeesWithoutSelf = attendees.filter(ea => !ea.self);
-    return attendeesWithoutSelf.length ? (" - " + attendeesWithoutSelf.map(ea => ea.email).join(", ")) : "";
+    return attendeesWithoutSelf.length ? (" - " + attendeesWithoutSelf.map(ea => ea.displayName || ea.email).join(", ")) : "";
   },
 
   formatEvent: function(event, tz, optionalTodayYMD, options) {
@@ -36,6 +36,12 @@ const EventFormatter = {
     } else {
       return this.formatEventWithoutDetails(event, tz, optionalTodayYMD, options);
     }
+  },
+
+  summaryLink: function(event) {
+    const linkText = `${event.summary}${this.formatAttendeesFor(event)}`;
+    const escaped = linkText.replace(/([\[\]<>])/g, "\\$1");
+    return `[${escaped}](${event.htmlLink})`;
   },
 
   formatEventWithDetails: function(event, tz, optionalTodayYMD, options) {
@@ -47,12 +53,12 @@ const EventFormatter = {
     if (event.location) {
       optionalData += `_Where: ${event.location}_  \n`;
     }
-    return `${time}  \n**[${event.summary}${this.formatAttendeesFor(event)}](${event.htmlLink})**  \n${optionalData}${this.formatHangoutLinkFor(event, options)}`;
+    return `${time}  \n**${this.summaryLink(event)}**  \n${optionalData}${this.formatHangoutLinkFor(event, options)}`;
   },
 
   formatEventWithoutDetails: function(event, tz, optionalTodayYMD, options) {
     const time = this.formatEventDateTime(event, tz, optionalTodayYMD);
-    return `${time}: **[${event.summary}${this.formatAttendeesFor(event)}](${event.htmlLink})**${this.formatHangoutLinkFor(event, options)}`;
+    return `${time}: **${this.summaryLink(event)}**${this.formatHangoutLinkFor(event, options)}`;
   },
 
   formatEventDateTime: function(event, tz, optionalTodayYMD) {

--- a/npm_modules/ellipsis-cal-date-format/package-lock.json
+++ b/npm_modules/ellipsis-cal-date-format/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ellipsis-cal-date-format",
-  "version": "0.0.6",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm_modules/ellipsis-cal-date-format/package.json
+++ b/npm_modules/ellipsis-cal-date-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ellipsis-cal-date-format",
-  "version": "0.0.6",
+  "version": "0.0.9",
   "description": "Format calendar events into human-friendly text",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When generating a summary link, ensure text is escaped properly, and that attendee display names are used when present