### PR TITLE
Try nuking node_modules before running activator/sbt to avoid NPM error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
             - v10-playapp-{{ arch }}-{{ .Branch }}-{{ checksum "build.sbt" }}
             - v10-playapp-{{ arch }}-{{ checksum "build.sbt" }}
       - run:
-          name: Erase node_modules before compiling
+          name: Erase node_modules before compiling to avoid Problems with NPM resolution
           command: |
             rm -rf node_modules
       - run:


### PR DESCRIPTION
This seems to prevent `java.lang.RuntimeException: Problems with NPM resolution. Aborting build.` on circleci