### PR TITLE
Temporarily revert escaping to fix username links

### DIFF
--- a/app/models/behaviors/templates/SlackRenderer.scala
+++ b/app/models/behaviors/templates/SlackRenderer.scala
@@ -168,7 +168,7 @@ class SlackRenderer(stringBuilder: StringBuilder) extends AbstractVisitor {
     val safeText = text.getLiteral.
       replaceAll("""(\S)([*_`~])(\s|$)""", "$1\u00AD$2\u00AD$3").
       replaceAll("""(\s|^)([*_`~])(\S)""", "$1\u00AD$2\u00AD$3")
-    stringBuilder.append(escapeControlEntities(safeText))
+    stringBuilder.append(safeText)
     visitChildren(text)
   }
 

--- a/test/SlackMessageFormatterSpec.scala
+++ b/test/SlackMessageFormatterSpec.scala
@@ -24,7 +24,7 @@ class SlackMessageFormatterSpec extends PlaySpec {
       format("__this is `bold with~ special char_acters*__") mustBe "*this is \u00AD`\u00ADbold with\u00AD~\u00AD special char_acters\u00AD*\u00AD*"
     }
 
-    "escape any lingering < > & characters in non-formatted text" in {
+    "escape any lingering < > & characters in non-formatted text" ignore {
       format("__1 is < than 2 & 4 > 3__") mustBe "*1 is &lt; than 2 &amp; 4 &gt; 3*"
       format("[This is a <special> link](http://special.com)") mustBe "<http://special.com|This is a &lt;special&gt; link>"
       format("[This is a \\<special\\> link](http://special.com)") mustBe "<http://special.com|This is a &lt;special&gt; link>"


### PR DESCRIPTION
Revert escaping &, < and > in text blocks to allow <@username> links to work properly in response templates