### PR TITLE
Don't show opaque API id in diff text

### DIFF
--- a/app/assets/javascripts/models/required_api_config.jsx
+++ b/app/assets/javascripts/models/required_api_config.jsx
@@ -28,7 +28,7 @@ define(function() {
     }
 
     kindLabel(): string {
-      return `required ${this.apiId} configuration`;
+      return `required API configuration`;
     }
 
     getIdForDiff(): string {


### PR DESCRIPTION
- this is the easy way to solve the problem; if we wanted to show the name of the API, it would require some more surgery that I couldn't convince myself was worth it