### PR TITLE
Made it possible to enable/disable dev mode for a channel

### DIFF
--- a/app/models/behaviors/builtins/BuiltinBehavior.scala
+++ b/app/models/behaviors/builtins/BuiltinBehavior.scala
@@ -31,6 +31,8 @@ object BuiltinBehavior {
   val revokeAuthRegex: Regex = s"""(?i)^revoke\\s+all\\s+tokens\\s+for\\s+(.*)""".r
   val feedbackRegex: Regex = s"""(?i)^(feedback|support): (.+)$$""".r
   val helloRegex: Regex = s"""(?i)^hello|hi|ola|ciao|bonjour$$""".r
+  val enableDevModeChannelRegex = s"""(?i)^enable dev mode$$""".r
+  val disableDevModeChannelRegex = s"""(?i)^disable dev mode$$""".r
 
   def maybeFrom(event: Event, services: DefaultServices): Option[BuiltinBehavior] = {
     if (event.includesBotMention) {
@@ -54,6 +56,8 @@ object BuiltinBehavior {
         case revokeAuthRegex(appName) => Some(RevokeAuthBehavior(appName, event, services))
         case feedbackRegex(feedbackType, message) => Some(FeedbackBehavior(feedbackType, message, event, services))
         case helloRegex() => Some(HelloBehavior(event, services))
+        case enableDevModeChannelRegex() => Some(EnableDevModeChannelBehavior(event, services))
+        case disableDevModeChannelRegex() => Some(DisableDevModeChannelBehavior(event, services))
         case _ => None
       }
     } else {

--- a/app/models/behaviors/builtins/DisableDevModeChannelBehavior.scala
+++ b/app/models/behaviors/builtins/DisableDevModeChannelBehavior.scala
@@ -1,0 +1,36 @@
+package models.behaviors.builtins
+
+import akka.actor.ActorSystem
+import models.behaviors.events.Event
+import models.behaviors.{BotResult, SimpleTextResult}
+import services.DefaultServices
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+case class DisableDevModeChannelBehavior(
+                                          event: Event,
+                                          services: DefaultServices
+                                        ) extends BuiltinBehavior {
+
+  def result(implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[BotResult] = {
+    val dataService = services.dataService
+    val problemResponse = SimpleTextResult(event, None, "There was a problem trying to disable dev mode", forcePrivateResponse = false)
+    event.maybeChannel.map { channel =>
+      for {
+        maybeTeam <- dataService.teams.find(event.teamId)
+        maybeDVC <- maybeTeam.map { team =>
+          dataService.devModeChannels.find(event.context, channel, team)
+        }.getOrElse(Future.successful(None))
+        result <- maybeDVC.map { dvc =>
+          dataService.devModeChannels.delete(dvc).map { _ =>
+            SimpleTextResult(event, None, s"OK, this channel is back in normal mode", forcePrivateResponse = false)
+          }
+        }.getOrElse(Future.successful(SimpleTextResult(event, None, "This channel was already in normal mode, so I left it there", forcePrivateResponse = false)))
+      } yield result
+    }.getOrElse {
+      Future.successful(problemResponse)
+    }
+  }
+
+}

--- a/app/models/behaviors/builtins/EnableDevModeChannelBehavior.scala
+++ b/app/models/behaviors/builtins/EnableDevModeChannelBehavior.scala
@@ -1,0 +1,40 @@
+package models.behaviors.builtins
+
+import akka.actor.ActorSystem
+import models.behaviors.events.Event
+import models.behaviors.{BotResult, SimpleTextResult}
+import services.DefaultServices
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+case class EnableDevModeChannelBehavior(
+                                       event: Event,
+                                       services: DefaultServices
+                                     ) extends BuiltinBehavior {
+
+  def result(implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[BotResult] = {
+    val dataService = services.dataService
+    val problemResponse = SimpleTextResult(event, None, "There was a problem trying to enable dev mode", forcePrivateResponse = false)
+    event.maybeChannel.map { channel =>
+      for {
+        maybeTeam <- dataService.teams.find(event.teamId)
+        maybeExisting <- maybeTeam.map { team =>
+          dataService.devModeChannels.find(event.context, channel, team)
+        }.getOrElse(Future.successful(None))
+        result <- maybeTeam.map { team =>
+          maybeExisting.map { _ =>
+            Future.successful(SimpleTextResult(event, None, s"This channel was already in dev mode, so I left it there", forcePrivateResponse = false))
+          }.getOrElse {
+            dataService.devModeChannels.ensureFor(event.context, channel, team).map { _ =>
+              SimpleTextResult(event, None, s"OK, this channel is now in dev mode", forcePrivateResponse = false)
+            }
+          }
+        }.getOrElse(Future.successful(problemResponse))
+      } yield result
+    }.getOrElse {
+      Future.successful(problemResponse)
+    }
+  }
+
+}

--- a/app/models/devmodechannel/DevModeChannelQueries.scala
+++ b/app/models/devmodechannel/DevModeChannelQueries.scala
@@ -1,0 +1,17 @@
+package models.devmodechannel
+
+import drivers.SlickPostgresDriver.api._
+
+object DevModeChannelQueries {
+
+  def all = TableQuery[DevModeChannelsTable]
+
+  def uncompiledFindQuery(context: Rep[String], channel: Rep[String], teamId: Rep[String]) = {
+    all.
+      filter(_.context === context).
+      filter(_.channel === channel).
+      filter(_.teamId === teamId)
+  }
+  val findQuery = Compiled(uncompiledFindQuery _)
+
+}

--- a/app/models/devmodechannel/DevModeChannelService.scala
+++ b/app/models/devmodechannel/DevModeChannelService.scala
@@ -1,0 +1,15 @@
+package models.devmodechannel
+
+import models.team.Team
+
+import scala.concurrent.Future
+
+trait DevModeChannelService {
+
+  def find(context: String, channel: String, team: Team): Future[Option[DevModeChannel]]
+
+  def ensureFor(context: String, channel: String, team: Team): Future[DevModeChannel]
+
+  def delete(devModeChannel: DevModeChannel): Future[Boolean]
+
+}

--- a/app/models/devmodechannel/DevModeChannelServiceImpl.scala
+++ b/app/models/devmodechannel/DevModeChannelServiceImpl.scala
@@ -1,0 +1,63 @@
+package models.devmodechannel
+
+import java.time.OffsetDateTime
+import javax.inject.Inject
+
+import com.google.inject.Provider
+import models.team._
+import services.DataService
+import drivers.SlickPostgresDriver.api._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class DevModeChannel(
+                           context: String, // "slack, etc"
+                           channel: String,
+                           teamId: String,
+                           createdAt: OffsetDateTime
+                         )
+
+class DevModeChannelsTable(tag: Tag) extends Table[DevModeChannel](tag, "dev_mode_channels") {
+
+  def context = column[String]("context")
+  def channel = column[String]("channel")
+  def teamId = column[String]("team_id")
+  def createdAt = column[OffsetDateTime]("created_at")
+
+  def * = (context, channel, teamId, createdAt) <> ((DevModeChannel.apply _).tupled, DevModeChannel.unapply _)
+}
+
+class DevModeChannelServiceImpl @Inject() (
+                                             dataServiceProvider: Provider[DataService],
+                                             implicit val ec: ExecutionContext
+                                           ) extends DevModeChannelService {
+
+  def dataService = dataServiceProvider.get
+
+  import DevModeChannelQueries._
+
+  def find(context: String, channel: String, team: Team): Future[Option[DevModeChannel]] = {
+    val action = findQuery(context, channel, team.id).result.map { r =>
+      r.headOption
+    }
+    dataService.run(action)
+  }
+
+  def ensureFor(context: String, channel: String, team: Team): Future[DevModeChannel] = {
+    val action = findQuery(context, channel, team.id).result.flatMap { r =>
+      r.headOption.map(DBIO.successful).getOrElse {
+        val newInstance = DevModeChannel(context, channel, team.id, OffsetDateTime.now)
+        (all += newInstance).map(_ => newInstance)
+      }
+    }
+    dataService.run(action)
+  }
+
+  def delete(devModeChannel: DevModeChannel): Future[Boolean] = {
+    val action = findQuery(devModeChannel.context, devModeChannel.channel, devModeChannel.teamId).delete.map { r =>
+      r > 0
+    }
+    dataService.run(action)
+  }
+
+}

--- a/app/modules/ServiceModule.scala
+++ b/app/modules/ServiceModule.scala
@@ -43,6 +43,7 @@ import models.behaviors.nodemoduleversion.{NodeModuleVersionService, NodeModuleV
 import models.behaviors.savedanswer.{SavedAnswerService, SavedAnswerServiceImpl}
 import models.behaviors.scheduling.recurrence.{RecurrenceService, RecurrenceServiceImpl}
 import models.behaviors.scheduling.scheduledbehavior.{ScheduledBehaviorService, ScheduledBehaviorServiceImpl}
+import models.devmodechannel.{DevModeChannelService, DevModeChannelServiceImpl}
 import models.team.{TeamService, TeamServiceImpl}
 import services._
 import net.codingwell.scalaguice.ScalaModule
@@ -96,6 +97,7 @@ class ServiceModule extends AbstractModule with ScalaModule {
     bind[BehaviorResponseService].to[BehaviorResponseServiceImpl]
     bind[BotResultService].to[BotResultServiceImpl]
     bind[NodeModuleVersionService].to[NodeModuleVersionServiceImpl]
+    bind[DevModeChannelService].to[DevModeChannelServiceImpl]
 
     bind[AWSLambdaService].to[AWSLambdaServiceImpl]
     bind[AWSLogsService].to[AWSLogsServiceImpl]

--- a/app/services/DataService.scala
+++ b/app/services/DataService.scala
@@ -39,6 +39,7 @@ import models.behaviors.scheduling.recurrence.RecurrenceService
 import models.behaviors.scheduling.scheduledbehavior.ScheduledBehaviorService
 import models.behaviors.scheduling.scheduledmessage.ScheduledMessageService
 import models.behaviors.triggers.messagetrigger.MessageTriggerService
+import models.devmodechannel.DevModeChannelService
 import models.environmentvariable.TeamEnvironmentVariableService
 import models.team.TeamService
 import slick.dbio.DBIO
@@ -87,6 +88,7 @@ trait DataService {
   val scheduledBehaviors: ScheduledBehaviorService
   val recurrences: RecurrenceService
   val invocationLogEntries: InvocationLogEntryService
+  val devModeChannels: DevModeChannelService
   def behaviorResponses: BehaviorResponseService
 
   def run[T](action: DBIO[T]): Future[T]

--- a/app/services/PostgresDataService.scala
+++ b/app/services/PostgresDataService.scala
@@ -42,6 +42,7 @@ import models.behaviors.scheduling.recurrence.RecurrenceService
 import models.behaviors.scheduling.scheduledbehavior.ScheduledBehaviorService
 import models.behaviors.scheduling.scheduledmessage.ScheduledMessageService
 import models.behaviors.triggers.messagetrigger.MessageTriggerService
+import models.devmodechannel.DevModeChannelService
 import models.environmentvariable.TeamEnvironmentVariableService
 import models.team.TeamService
 import slick.dbio.DBIO
@@ -91,6 +92,7 @@ class PostgresDataService @Inject() (
                                       val scheduledBehaviorsProvider: Provider[ScheduledBehaviorService],
                                       val recurrencesProvider: Provider[RecurrenceService],
                                       val invocationLogEntriesProvider: Provider[InvocationLogEntryService],
+                                      val devModeChannelsProvider: Provider[DevModeChannelService],
                                       val behaviorResponsesProvider: Provider[BehaviorResponseService]
                             ) extends DataService {
 
@@ -134,6 +136,7 @@ class PostgresDataService @Inject() (
   val scheduledBehaviors = scheduledBehaviorsProvider.get
   val recurrences = recurrencesProvider.get
   val invocationLogEntries = invocationLogEntriesProvider.get
+  val devModeChannels = devModeChannelsProvider.get
   def behaviorResponses = behaviorResponsesProvider.get
 
   def run[T](action: DBIO[T]): Future[T] = models.run(action)

--- a/conf/evolutions/default/115.sql
+++ b/conf/evolutions/default/115.sql
@@ -1,0 +1,13 @@
+# --- !Ups
+
+CREATE TABLE dev_mode_channels (
+  context TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY(context, channel, team_id)
+);
+
+# --- !Downs
+
+DROP TABLE dev_mode_channels;

--- a/test/mocks/MockDataService.scala
+++ b/test/mocks/MockDataService.scala
@@ -41,6 +41,7 @@ import models.behaviors.scheduling.recurrence.RecurrenceService
 import models.behaviors.scheduling.scheduledbehavior.ScheduledBehaviorService
 import models.behaviors.scheduling.scheduledmessage.ScheduledMessageService
 import models.behaviors.triggers.messagetrigger.MessageTriggerService
+import models.devmodechannel.DevModeChannelService
 import models.environmentvariable.TeamEnvironmentVariableService
 import models.team.TeamService
 import org.scalatest.mock.MockitoSugar
@@ -92,6 +93,7 @@ class MockDataService extends DataService with MockitoSugar {
   val scheduledBehaviors = mock[ScheduledBehaviorService]
   val recurrences = mock[RecurrenceService]
   val invocationLogEntries = mock[InvocationLogEntryService]
+  val devModeChannels = mock[DevModeChannelService]
   val behaviorResponses = mock[BehaviorResponseService]
 
   private def dontCallMe = throw new Exception("Don't call me")


### PR DESCRIPTION
- this currently has no effect, but I'll use it soon with deployed skill versions
- we can also use it to decide how much debugging info to display, or unlock dev builtins