### PR TITLE
Fix bottom padding on skill editor

### DIFF
--- a/app/assets/javascripts/behavior_editor/behavior_group_editor.jsx
+++ b/app/assets/javascripts/behavior_editor/behavior_group_editor.jsx
@@ -81,7 +81,7 @@ define(function(require) {
 
           <hr className="mvxxl rule-subtle" />
 
-          <div className="container container-narrow">
+          <div className="container container-narrow mbxl">
 
             <div className="columns columns-elastic mobile-columns-float">
               <div className="column column-expand mobile-mbm">

--- a/app/assets/javascripts/behavior_editor/index.jsx
+++ b/app/assets/javascripts/behavior_editor/index.jsx
@@ -2389,7 +2389,7 @@ const BehaviorEditor = React.createClass({
 
   renderDataTypeBehavior: function() {
     return (
-      <div className="pbxxxl">
+      <div>
         <div className="bg-white pbl" />
         <hr className="mtn mbn rule-subtle" />
 
@@ -2503,7 +2503,10 @@ const BehaviorEditor = React.createClass({
                 (this.props.activePanelName === 'versionBrowser' || this.state.versionBrowserOpen) ? "position-frozen" : ""
                }`}>
                 {this.renderBehaviorSwitcher()}
-                <div className="column column-page-main column-page-main-wide flex-column flex-column-main pbxxl">
+                <div
+                  className="column column-page-main column-page-main-wide flex-column flex-column-main"
+                  style={{ paddingBottom: `${this.props.footerHeight}px `}}
+                >
                   {this.renderSwitcherToggle()}
 
                   {this.renderEditor()}

--- a/app/assets/javascripts/behavior_editor/response_template_configuration.jsx
+++ b/app/assets/javascripts/behavior_editor/response_template_configuration.jsx
@@ -33,7 +33,7 @@ define(function(require) {
       return (
         <div className="columns container container-wide">
 
-          <div className="mbxxxl ptxl">
+          <div className="mbl ptxl">
             <SectionHeading number={this.props.sectionNumber}>
               <span className="mrm">Then respond</span>
               <span className="display-inline-block">


### PR DESCRIPTION
Notifications sometimes made it impossible to see the bottom of the editor