### PR TITLE
A couple of fixes for data types

### DIFF
--- a/app/models/behaviors/behaviorparameter/BehaviorParameterType.scala
+++ b/app/models/behaviors/behaviorparameter/BehaviorParameterType.scala
@@ -530,7 +530,7 @@ case class BehaviorBackedDataType(dataTypeConfig: DataTypeConfig) extends Behavi
   }
 
   private def fetchMatchFor(text: String, context: BehaviorParameterContext)(implicit ec: ExecutionContext): Future[Option[ValidValue]] = {
-    fetchValidValues(None, context).map { validValues =>
+    fetchValidValues(Some(text), context).map { validValues =>
       validValues.find {
         v => v.id == text || textMatchesLabel(text, v.label, context)
       }

--- a/app/models/behaviors/conversations/conversation/Conversation.scala
+++ b/app/models/behaviors/conversations/conversation/Conversation.scala
@@ -101,12 +101,10 @@ trait Conversation {
                  event: Event,
                  services: DefaultServices
                )(implicit ec: ExecutionContext): Future[BotResult] = {
-    (for {
+    for {
       updatedConversation <- updateWith(event, services)
       result <- updatedConversation.respond(event, isReminding=false, services)
-    } yield result).recover {
-      case e: FetchValidValuesBadResultException => e.result
-    }
+    } yield result
   }
 
   def maybeNextParamToCollect(


### PR DESCRIPTION
- Move error handling for error result cases up higher to cover more cases
- Pass the text through to the searchQuery param