### PR TITLE
This should actually fix spurious whitespace diffs. I think.

### DIFF
--- a/app/json/BehaviorVersionData.scala
+++ b/app/json/BehaviorVersionData.scala
@@ -151,7 +151,7 @@ object BehaviorVersionData {
       Some(isNew),
       config.name,
       description,
-      functionBody,
+      functionBody.trim,
       responseTemplate,
       inputIds,
       triggers.sorted,

--- a/app/models/behaviors/behaviorversion/BehaviorVersionServiceImpl.scala
+++ b/app/models/behaviors/behaviorversion/BehaviorVersionServiceImpl.scala
@@ -202,7 +202,7 @@ class BehaviorVersionServiceImpl @Inject() (
         groupVersion,
         raw.maybeDescription,
         raw.maybeName,
-        raw.maybeFunctionBody,
+        raw.maybeFunctionBody.map(_.trim),
         raw.maybeResponseTemplate,
         raw.forcePrivateResponse,
         maybeUser,

--- a/app/services/AWSLambdaServiceImpl.scala
+++ b/app/services/AWSLambdaServiceImpl.scala
@@ -313,7 +313,7 @@ class AWSLambdaServiceImpl @Inject() (
     val paramNames = params.map(_.input.name)
     val paramDecoration = if (isForExport) { "" } else { decorateParams(params) }
     s"""function(${(paramNames ++ Array(CONTEXT_PARAM)).mkString(", ")}) {
-        |  $paramDecoration${functionBody}
+        |  $paramDecoration${functionBody.trim}
         |}\n""".stripMargin
   }
 


### PR DESCRIPTION
- basically just trim function bodies always, on save/export/etc