### PR TITLE
Skill page improvements

### DIFF
--- a/app/assets/frontend/behavior_list/behavior_group_card.tsx
+++ b/app/assets/frontend/behavior_list/behavior_group_card.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import BehaviorGroup from '../models/behavior_group';
-import SVGInstalled from '../svg/installed';
 import Button from "../form/button";
 import autobind from "../lib/autobind";
 import BehaviorVersion from "../models/behavior_version";

--- a/app/assets/frontend/behavior_list/behavior_group_info_panel.tsx
+++ b/app/assets/frontend/behavior_list/behavior_group_info_panel.tsx
@@ -17,7 +17,7 @@ import autobind from '../lib/autobind';
     updatedData: BehaviorGroup | null,
     onToggle: () => void,
     isImportable: boolean,
-    wasImported: boolean,
+    isPublished: boolean,
     isImporting: boolean,
     localId: string | null
   }
@@ -134,7 +134,7 @@ import autobind from '../lib/autobind';
     }
 
     renderUpdate() {
-      if (this.props.updatedData) {
+      if (this.props.updatedData && this.props.localId) {
         return (
           <div className="mvl fade-in">
             <DynamicLabelButton
@@ -165,7 +165,7 @@ import autobind from '../lib/autobind';
             </a>
           </div>
         );
-      } else if (this.props.wasImported) {
+      } else if (this.props.isPublished) {
         return (
           <div className={`type-s mvm fade-in ${this.props.isImporting ? "pulse" : ""}`}>
             <span className="display-inline-block align-m mrs" style={{ width: 30, height: 18 }}><SVGInstalled /></span>

--- a/app/assets/frontend/behavior_list/index.tsx
+++ b/app/assets/frontend/behavior_list/index.tsx
@@ -21,7 +21,6 @@ import {SearchResult} from "./loader";
 import SVGInstall from '../svg/install';
 import SVGInstalled from '../svg/installed';
 import SVGInstalling from '../svg/installing';
-import SVGCheckmark from '../svg/checkmark';
 
 const ANIMATION_DURATION = 0.25;
 
@@ -403,13 +402,18 @@ class BehaviorList extends React.Component<Props, State> {
     return Boolean(selectedGroup && selectedGroup.exportId && !this.getLocalIdFor(selectedGroup.exportId));
   }
 
-  selectedBehaviorWasImported(): boolean {
-    var selectedGroup = this.getSelectedBehaviorGroup();
+  groupIsPublished(group: BehaviorGroup | null): boolean {
     return Boolean(
-      selectedGroup &&
-      selectedGroup.id &&
-      selectedGroup.exportId &&
-      BehaviorGroup.groupsIncludeExportId(this.props.publishedBehaviorGroups, selectedGroup.exportId)
+      group &&
+      group.exportId &&
+      BehaviorGroup.groupsIncludeExportId(this.props.publishedBehaviorGroups, group.exportId)
+    );
+  }
+
+  publishedGroupWasImported(group: BehaviorGroup): boolean {
+    return Boolean(
+      group.exportId &&
+      BehaviorGroup.groupsIncludeExportId(this.getLocalBehaviorGroups(), group.exportId)
     );
   }
 
@@ -629,18 +633,18 @@ class BehaviorList extends React.Component<Props, State> {
     }
   }
 
-  renderInstallActionsFor(group: BehaviorGroup) {
+  renderInstallActionsFor(publishedGroup: BehaviorGroup) {
     const onImportforGroup = () => {
-      this.onBehaviorGroupImport(group);
+      this.onBehaviorGroupImport(publishedGroup);
     };
-    if (this.isImporting(group)) {
+    if (this.isImporting(publishedGroup)) {
       return (
         <Button title="Installing, please wait…" className="button-raw button-no-wrap height-xl" disabled={true} onClick={null}>
           <span className="display-inline-block align-m mrs" style={{width: 40, height: 24}}><SVGInstalling /></span>
           <span className="display-inline-block align-m">Installing…</span>
         </Button>
       );
-    } else if (group.id) {
+    } else if (this.publishedGroupWasImported(publishedGroup)) {
       return (
         <Button title="Already installed" className="button-raw button-no-wrap height-xl" disabled={true} onClick={null}>
           <span className="display-inline-block align-m mrs" style={{width: 40, height: 24}}><SVGInstalled /></span>
@@ -826,7 +830,7 @@ class BehaviorList extends React.Component<Props, State> {
                 groupData={this.getSelectedBehaviorGroup()}
                 onToggle={this.clearActivePanel}
                 isImportable={this.selectedBehaviorGroupIsUninstalled()}
-                wasImported={this.selectedBehaviorWasImported()}
+                isPublished={this.groupIsPublished(this.getSelectedBehaviorGroup())}
                 isImporting={this.isImporting(this.getSelectedBehaviorGroup())}
                 localId={this.getSelectedBehaviorGroupId()}
                 onBehaviorGroupImport={this.onBehaviorGroupImport}

--- a/app/assets/frontend/behavior_list/loader.tsx
+++ b/app/assets/frontend/behavior_list/loader.tsx
@@ -139,14 +139,7 @@ class BehaviorListLoader extends React.Component<Props, State> {
   didImportPublishedGroup(publishedGroup: BehaviorGroup, importedGroup: BehaviorGroup): void {
     this.setState({
       currentlyInstalling: this.state.currentlyInstalling.filter((ea) => ea !== publishedGroup),
-      recentlyInstalled: this.state.recentlyInstalled.concat(importedGroup),
-      publishedBehaviorGroups: this.state.publishedBehaviorGroups.map((ea) => {
-        if (ea === publishedGroup) {
-          return ea.clone({ id: importedGroup.id });
-        } else {
-          return ea;
-        }
-      })
+      recentlyInstalled: this.state.recentlyInstalled.concat(importedGroup)
     });
   }
 

--- a/test/assets/frontend/behavior_list/behavior_list_loader_spec.js
+++ b/test/assets/frontend/behavior_list/behavior_list_loader_spec.js
@@ -20,8 +20,9 @@ jest.setMock('../../../../app/assets/frontend/lib/data_request', { DataRequest: 
 
 describe('BehaviorListApp', () => {
   jsRoutes.controllers.ApplicationController.fetchPublishedBehaviorInfo = () => ({ url: '/fetch', method: 'get' });
-  jsRoutes.controllers.BehaviorEditorController.newGroup = () => ({ url: '/newGroup', method: 'get' });
   jsRoutes.controllers.ApplicationController.possibleCitiesFor = () => ({ url: '/possibleCitiesFor', method: 'get' });
+  jsRoutes.controllers.BehaviorEditorController.edit = () => ({ url: '/edit', method: 'get' });
+  jsRoutes.controllers.BehaviorEditorController.newGroup = () => ({ url: '/newGroup', method: 'get' });
 
   const behaviorVersionTask1 = Object.freeze({
     "teamId": "abcdef",


### PR DESCRIPTION
1. Add an Edit link to the cards to quickly get to the edit page
2. Keep the info panel open when re-installing, and ensure the displayed data is up-to-date once it finishes
