### PR TITLE
Fix the `@ellipsis` → `I don’t know anything related to “@ellipsis”.` bug

### DIFF
--- a/app/models/behaviors/events/Event.scala
+++ b/app/models/behaviors/events/Event.scala
@@ -117,7 +117,7 @@ trait Event {
   def noExactMatchResult(services: DefaultServices)
                         (implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[BotResult] = {
     DisplayHelpBehavior(
-      Some(messageText),
+      Some(relevantMessageText),
       None,
       Some(0),
       includeNameAndDescription = true,


### PR DESCRIPTION
When there's no exact trigger match for a bot-mentioning message, only pass the _relevant_ message text (without the bot prefix), instead of the whole thing. Fixes the weird case where if you just write the bot's name or "..." by itself, it says there are no matches for that. :facepalm:
