### PR TITLE
Convert @usernames back into <@U###> links in responses

### DIFF
--- a/app/models/behaviors/behaviorparameter/BehaviorParameterType.scala
+++ b/app/models/behaviors/behaviorparameter/BehaviorParameterType.scala
@@ -220,7 +220,7 @@ object YesNoType extends BuiltInType {
     super.promptResultForAction(maybePreviousCollectedValue, context, paramState, isReminding).map { superPromptResult =>
       val callbackId = context.yesNoCallbackId
       val actionList = Seq(SlackMessageActionButton(callbackId, "Yes", YES), SlackMessageActionButton(callbackId, "No", NO))
-      val actionsGroup = SlackMessageActionsGroup(callbackId, actionList, None, None)
+      val actionsGroup = SlackMessageActionsGroup(callbackId, actionList, None, None, None)
       TextWithAttachmentsResult(
         superPromptResult.event,
         superPromptResult.maybeConversation,
@@ -605,7 +605,7 @@ case class BehaviorBackedDataType(dataTypeConfig: DataTypeConfig) extends Behavi
         } ++ builtinMenuItems
         val actionsList = Seq(SlackMessageActionMenu("ignored", "Choose an option", menuItems))
         val groups: Seq[MessageAttachmentGroup] = Seq(
-          SlackMessageActionsGroup(context.dataTypeChoiceCallbackId, actionsList, None, Some(Color.BLUE_LIGHT))
+          SlackMessageActionsGroup(context.dataTypeChoiceCallbackId, actionsList, None, None, Some(Color.BLUE_LIGHT))
         )
         DBIO.successful(TextWithAttachmentsResult(context.event, context.maybeConversation, superPrompt, context.behaviorVersion.forcePrivateResponse, groups))
       }

--- a/app/models/behaviors/builtins/DisplayHelpBehavior.scala
+++ b/app/models/behaviors/builtins/DisplayHelpBehavior.scala
@@ -76,6 +76,7 @@ case class DisplayHelpBehavior(
       SHOW_HELP_INDEX,
       actionList,
       maybeInstructions,
+      None,
       Some(Color.PINK),
       if (startAt == 0) { Some("Skills") } else { None }
     )
@@ -95,7 +96,7 @@ case class DisplayHelpBehavior(
   }
 
   def generalHelpGroup(botPrefix: String): SlackMessageAttachmentGroup = {
-    SlackMessageTextAttachmentGroup(generalHelpText(botPrefix: String), Some("General"))
+    SlackMessageTextAttachmentGroup(generalHelpText(botPrefix: String), None, Some("General"))
   }
 
   def skillNameAndDescriptionFor(result: HelpResult): String = {
@@ -143,7 +144,7 @@ case class DisplayHelpBehavior(
       Some("Select or type an action to run it now:")
     }
 
-    val actionsGroup = SlackMessageActionsGroup(SHOW_BEHAVIOR_GROUP_HELP, actionList, actionText, Some(Color.BLUE_LIGHT), None)
+    val actionsGroup = SlackMessageActionsGroup(SHOW_BEHAVIOR_GROUP_HELP, actionList, actionText, None, Some(Color.BLUE_LIGHT), None)
 
     TextWithAttachmentsResult(event, None, resultText, forcePrivateResponse = false, Seq(actionsGroup))
   }
@@ -151,7 +152,7 @@ case class DisplayHelpBehavior(
   def emptyResult(botPrefix: String): BotResult = {
     val actionList = Seq(SlackMessageActionButton(SHOW_HELP_INDEX, "More help…", "0"))
     val resultText = s"I don’t know anything$matchString."
-    val actionsGroup = SlackMessageActionsGroup("help_no_result", actionList, None, Some(Color.PINK))
+    val actionsGroup = SlackMessageActionsGroup("help_no_result", actionList, None, None, Some(Color.PINK))
     TextWithAttachmentsResult(event, None, resultText, forcePrivateResponse = false, Seq(generalHelpGroup(botPrefix), actionsGroup))
   }
 

--- a/app/models/behaviors/conversations/conversation/Conversation.scala
+++ b/app/models/behaviors/conversations/conversation/Conversation.scala
@@ -123,7 +123,7 @@ trait Conversation {
           val callbackId = stopConversationCallbackIdFor(event.userIdForContext, Some(id))
           val actionList = Seq(SlackMessageActionButton(callbackId, "Stop asking", id))
           val question = result.text
-          val actionsGroup = SlackMessageActionsGroup(callbackId, actionList, Some(question), None)
+          val actionsGroup = SlackMessageActionsGroup(callbackId, actionList, Some(question), None, None)
           Some(TextWithAttachmentsResult(result.event, Some(this), intro, result.forcePrivateResponse, Seq(actionsGroup)))
         }
       }.getOrElse(DBIO.successful(None))

--- a/app/models/behaviors/events/EventHandler.scala
+++ b/app/models/behaviors/events/EventHandler.scala
@@ -1,7 +1,7 @@
 package models.behaviors.events
 
 import javax.inject._
-
+import json.SlackUserData
 import models.behaviors.behaviorparameter.FetchValidValuesBadResultException
 import models.behaviors.builtins.BuiltinBehavior
 import models.behaviors.conversations.conversation.Conversation
@@ -87,7 +87,11 @@ class EventHandler @Inject() (
             }.getOrElse {
               s"It’s been a while since I asked you the question above."
             } + s"\n\nJust so I’m sure, is this an answer?"
-            val actions = SlackMessageActionsGroup(callbackId, actionList, Some(event.relevantMessageTextWithFormatting), Some(Color.PINK))
+            val maybeSlackUserList = event match {
+              case slackMessageEvent: SlackMessageEvent => Some(slackMessageEvent.message.userList)
+              case _ => None
+            }
+            val actions = SlackMessageActionsGroup(callbackId, actionList, Some(event.relevantMessageTextWithFormatting), maybeSlackUserList, Some(Color.PINK))
             TextWithAttachmentsResult(event, Some(updatedConvo), prompt, forcePrivateResponse = false, Seq(actions))
           }
         } else {

--- a/app/models/behaviors/events/RunEvent.scala
+++ b/app/models/behaviors/events/RunEvent.scala
@@ -1,6 +1,7 @@
 package models.behaviors.events
 
 import akka.actor.ActorSystem
+import json.SlackUserData
 import models.accounts.slack.botprofile.SlackBotProfile
 import models.accounts.user.User
 import models.behaviors.{ActionChoice, BehaviorResponse}
@@ -79,7 +80,8 @@ case class RunEvent(
         files,
         choices,
         configuration,
-        botName
+        botName,
+        Set.empty[SlackUserData]
       ).send
     } yield maybeTs
   }

--- a/app/models/behaviors/events/SlackMessage.scala
+++ b/app/models/behaviors/events/SlackMessage.scala
@@ -6,7 +6,7 @@ import services.SlackEventService
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class SlackMessage(originalText: String, withoutBotPrefix: String, unformattedText: String)
+case class SlackMessage(originalText: String, withoutBotPrefix: String, unformattedText: String, userList: Set[SlackUserData])
 
 object SlackMessage {
   def unformatLinks(text: String): String = {
@@ -46,7 +46,7 @@ object SlackMessage {
 
   def fromUnformattedText(text: String, botUserId: String): SlackMessage = {
     val withoutBotPrefix = removeBotPrefix(text, botUserId)
-    SlackMessage(text, withoutBotPrefix, withoutBotPrefix)
+    SlackMessage(text, withoutBotPrefix, withoutBotPrefix, Set.empty[SlackUserData])
   }
 
   def userIdsInText(text: String): Set[String] = {
@@ -59,9 +59,9 @@ object SlackMessage {
     for {
       slackUsers <- slackEventService.slackUserDataList(userList, botProfile)
     } yield {
-      SlackMessage(text, withoutBotPrefix, unformatTextWithUsers(withoutBotPrefix, slackUsers))
+      SlackMessage(text, withoutBotPrefix, unformatTextWithUsers(withoutBotPrefix, slackUsers), slackUsers)
     }
   }
 
-  def blank: SlackMessage = SlackMessage("", "", "")
+  def blank: SlackMessage = SlackMessage("", "", "", Set.empty[SlackUserData])
 }

--- a/app/models/behaviors/events/SlackMessageActionsGroup.scala
+++ b/app/models/behaviors/events/SlackMessageActionsGroup.scala
@@ -1,11 +1,13 @@
 package models.behaviors.events
 
+import json.SlackUserData
 import utils.SlackMessageSender
 
 case class SlackMessageActionsGroup(
                                 id: String,
                                 actions: Seq[SlackMessageAction],
                                 maybeText: Option[String],
+                                maybeSlackUserList: Option[Set[SlackUserData]],
                                 maybeColor: Option[String],
                                 maybeTitle: Option[String] = None,
                                 maybeTitleLink: Option[String] = None
@@ -21,6 +23,7 @@ case class SlackMessageActionsGroup(
       if (index == 0) {
         SlackMessageAttachment(
           maybeText,
+          maybeSlackUserList,
           maybeTitle,
           maybeTitleLink,
           maybeColor,
@@ -29,6 +32,7 @@ case class SlackMessageActionsGroup(
         )
       } else {
         SlackMessageAttachment(
+          None,
           None,
           None,
           None,

--- a/app/models/behaviors/events/SlackMessageAttachment.scala
+++ b/app/models/behaviors/events/SlackMessageAttachment.scala
@@ -1,10 +1,12 @@
 package models.behaviors.events
 
+import json.SlackUserData
 import models.SlackMessageFormatter
 import slack.models.{ActionField, Attachment}
 
 case class SlackMessageAttachment(
                                    maybeText: Option[String],
+                                   maybeSlackUserList: Option[Set[SlackUserData]],
                                    maybeTitle: Option[String] = None,
                                    maybeTitleLink: Option[String] = None,
                                    maybeColor: Option[String] = None,
@@ -21,7 +23,7 @@ case class SlackMessageAttachment(
     author_icon = None,
     title = maybeTitle,
     title_link = maybeTitleLink,
-    text = maybeText.map(SlackMessageFormatter.bodyTextFor),
+    text = maybeText.map(text => SlackMessageFormatter.bodyTextFor(text, maybeSlackUserList.getOrElse(Set.empty[SlackUserData]))),
     fields = Seq(),
     image_url = None,
     thumb_url = None,

--- a/app/models/behaviors/events/SlackMessageEvent.scala
+++ b/app/models/behaviors/events/SlackMessageEvent.scala
@@ -139,7 +139,8 @@ case class SlackMessageEvent(
         files,
         choices,
         configuration,
-        botName
+        botName,
+        message.userList
       ).send
     } yield maybeTs
   }

--- a/app/models/behaviors/events/SlackMessageTextAttachmentGroup.scala
+++ b/app/models/behaviors/events/SlackMessageTextAttachmentGroup.scala
@@ -1,15 +1,18 @@
 package models.behaviors.events
 
+import json.SlackUserData
 import utils.Color
 
 case class SlackMessageTextAttachmentGroup(
                                           text: String,
+                                          maybeSlackUserList: Option[Set[SlackUserData]],
                                           maybeTitle: Option[String] = None
                                         ) extends SlackMessageAttachmentGroup {
 
   val attachments: Seq[SlackMessageAttachment] = {
     Seq(SlackMessageAttachment(
       Some(text),
+      maybeSlackUserList,
       maybeTitle,
       None,
       Some(Color.BLUE_LIGHT)

--- a/test/SlackMessageEventSpec.scala
+++ b/test/SlackMessageEventSpec.scala
@@ -1,5 +1,6 @@
 import java.time.OffsetDateTime
 
+import json.SlackUserData
 import models.IDs
 import models.accounts.slack.botprofile.SlackBotProfile
 import models.behaviors.events.{SlackMessage, SlackMessageEvent}
@@ -29,7 +30,7 @@ class SlackMessageEventSpec extends PlaySpec with MockitoSugar {
       channel,
       None,
       IDs.next,
-      SlackMessage("oh hai", "oh hai", "oh hai"),
+      SlackMessage("oh hai", "oh hai", "oh hai", Set.empty[SlackUserData]),
       None,
       OffsetDateTime.now.toString,
       SlackApiClient(botToken),

--- a/test/SlackMessageFormatterSpec.scala
+++ b/test/SlackMessageFormatterSpec.scala
@@ -1,10 +1,20 @@
+import json.{SlackUserData, SlackUserProfileData}
 import models.SlackMessageFormatter
 import org.scalatestplus.play.PlaySpec
 
 class SlackMessageFormatterSpec extends PlaySpec {
 
+  def slackUserData(userId: String, username: String, displayName: String): SlackUserData = {
+    SlackUserData(userId, "T1", username, isPrimaryOwner = false, isOwner = false, isRestricted = false, isUltraRestricted = false, None, deleted = false, Some(SlackUserProfileData(Some(displayName), None, None, None)))
+  }
+  val slackUserList: Set[SlackUserData] = Set(
+    slackUserData("U1", "alligator", "Alligatór"),
+    slackUserData("U2", "baboon", "A Baboon!"),
+    slackUserData("U3", "crocodile", "Mr. Croc O. Dile")
+  )
+
   def format(original: String): String = {
-    SlackMessageFormatter.bodyTextFor(original).trim
+    SlackMessageFormatter.bodyTextFor(original, slackUserList).trim
   }
 
   "bodyTextFor" should {
@@ -46,6 +56,12 @@ class SlackMessageFormatterSpec extends PlaySpec {
                     |
                     |There should be a line above this""".stripMargin
       val output = "There should be a line below this\r\r─────\r\rThere should be a line above this"
+      format(input) mustBe output
+    }
+
+    "converts usernames into links" in {
+      val input = """@A Baboon! has a message for @Alligatór: time to meet @Mr. Croc O. Dile."""
+      val output = "<@U2> has a message for <@U1>: time to meet <@U3>."
       format(input) mustBe output
     }
 


### PR DESCRIPTION
When sending responses in Slack, convert any @usernames that were converted from user IDs to names in the original trigger and params back into proper user ID links <@U###> in the response, so users mentioned in the response are properly highlighted in Slack.

This specifically does *not* convert any usernames that might be valid but weren't part of any user trigger or input for the current action. To do that, it seems like we would need to fetch a list of all of the users on the team.

Resolves #2394 