### PR TITLE
Add a new message to acknowledge Slack actions

### DIFF
--- a/app/controllers/SlackController.scala
+++ b/app/controllers/SlackController.scala
@@ -6,7 +6,7 @@ import com.mohiva.play.silhouette.api.{LoginInfo, Silhouette}
 import json.Formatting._
 import models.accounts.linkedaccount.LinkedAccount
 import models.accounts.slack.botprofile.SlackBotProfile
-import models.behaviors.{ActionChoice, SimpleTextResult, TextWithAttachmentsResult}
+import models.behaviors.{ActionChoice, SimpleTextResult}
 import models.behaviors.behaviorgroupversion.BehaviorGroupVersion
 import models.behaviors.builtins.DisplayHelpBehavior
 import models.behaviors.conversations.conversation.Conversation
@@ -831,21 +831,21 @@ class SlackController @Inject() (
 
     def result: Result = {
 
-      // respond immediately by adding a new attachment and sending a message
-      val maybeOriginalColor = info.original_message.attachments.headOption.flatMap(_.color)
-      val newAttachment = AttachmentInfo(
-        maybeResultText,
-        title = None,
-        text = None,
-        Some(Seq("text")),
-        Some(info.callback_id),
-        color = maybeOriginalColor,
-        footer = Some("✔︎︎ OK")
-      )
+      // respond immediately by sending a new message
       maybeResultText.foreach(instantBackgroundResponse)
       runInBackground
 
       val updated = if (shouldRemoveActions) {
+        val maybeOriginalColor = info.original_message.attachments.headOption.flatMap(_.color)
+        val newAttachment = AttachmentInfo(
+          maybeResultText,
+          title = None,
+          text = None,
+          Some(Seq("text")),
+          Some(info.callback_id),
+          color = maybeOriginalColor,
+          footer = Some("✔︎︎ OK")
+        )
         val attachments = info.original_message.attachments.map(ea => ea.copy(actions = None))
         info.original_message.copy(attachments = attachments :+ newAttachment)
       } else {


### PR DESCRIPTION
Only adds a new attachment to the original message if we're removing the actions, and uses short text instead of saying the same thing twice.

<img width="410" alt="image" src="https://user-images.githubusercontent.com/71433/38443721-aecd8764-39ba-11e8-88b5-5533c3eec2b0.png">
