### PR TITLE
Use the right bot profile for sending Slack action acknowledgments

### DIFF
--- a/app/controllers/SlackController.scala
+++ b/app/controllers/SlackController.scala
@@ -802,10 +802,10 @@ class SlackController @Inject() (
 
     def instantBackgroundResponse(responseText: String): Future[Unit] = {
       for {
-        maybeSlackBotProfile <- dataService.slackBotProfiles.allForSlackTeamId(info.slackTeamIdToUse).map(_.headOption)
+        maybeBotProfile <- info.maybeBotProfile
       } yield {
         (for {
-          botProfile <- maybeSlackBotProfile
+          botProfile <- maybeBotProfile
         } yield {
           dataService.slackBotProfiles.sendResultWithNewEvent(
             "Message acknowledging response to Slack action",


### PR DESCRIPTION
I was using the wrong slack team ID so it was broken for talking to other teams' bots