### PR TITLE
Go back to using conversation id to test for interruption

### DIFF
--- a/app/models/behaviors/BotResult.scala
+++ b/app/models/behaviors/BotResult.scala
@@ -163,7 +163,7 @@ sealed trait BotResult {
         interruptionResults <- {
           val toInterrupt =
             ongoingWithRoots.
-              filterNot { case(_, root) => maybeRoot.contains(root) }.
+              filterNot { case(_, root) => maybeRoot.map(_.id).contains(root.id) }.
               map { case(convo, _) => convo }
           DBIO.sequence(toInterrupt.map { ea =>
             dataService.conversations.backgroundAction(ea, interruptionPrompt, includeUsername = true)


### PR DESCRIPTION
- don't want to interrupt if the conversation state has changed, for example