### PR TITLE
Fix "General" navigation list for chat not to use raw URLs

### DIFF
--- a/app/models/behaviors/events/Event.scala
+++ b/app/models/behaviors/events/Event.scala
@@ -95,8 +95,8 @@ trait Event {
 
   def navLinks(lambdaService: AWSLambdaService): String = {
     navLinkList(lambdaService).map { case(title, path) =>
-      s"$title: $path"
-    }.mkString("\n")
+      s"[$title]($path)"
+    }.mkString("  ·  ")
   }
 
   def teachMeLinkFor(lambdaService: AWSLambdaService): String = {

--- a/app/models/behaviors/events/SlackMessageEvent.scala
+++ b/app/models/behaviors/events/SlackMessageEvent.scala
@@ -87,12 +87,6 @@ case class SlackMessageEvent(
     dataService.conversations.findOngoingFor(user, context, maybeChannel, Some(ts), teamId)
   }
 
-  override def navLinks(lambdaService: AWSLambdaService): String = {
-    navLinkList(lambdaService).map { case(title, path) =>
-      s"[$title]($path)"
-    }.mkString("  ·  ")
-  }
-
   def channelForSend(
                       forcePrivate: Boolean,
                       maybeConversation: Option[Conversation],


### PR DESCRIPTION
Fix the list of nav links that is used in certain circumstances like non-triggering scheduled messages to use Markdown links instead of a weird shitty format