### PR TITLE
Subtler admin mode

### DIFF
--- a/app/assets/stylesheets/colors.less
+++ b/app/assets/stylesheets/colors.less
@@ -106,6 +106,9 @@
 @pink-lightest: hsl(341, 95%, 97%);
 .color-pink-lightest { color: @pink-lightest; }
 
+@bluish-pink: #f44cf9;
+.color-bluish-pink { color: @bluish-pink; }
+
 @green-dark: hsl(127, 93%, 20%);
 .color-green-dark { color: @green-dark; }
 

--- a/app/views/page/main.scala.html
+++ b/app/views/page/main.scala.html
@@ -10,8 +10,6 @@
 @navBgColorForPage = @{
   if (hideNav) {
     "bg-black type-white"
-  } else if (config.isAdmin) {
-    "bg-lightest-translucent bg-warning type-black"
   } else {
     "bg-white-translucent type-black"
   }

--- a/app/views/shared/mainLogo.scala.html
+++ b/app/views/shared/mainLogo.scala.html
@@ -12,7 +12,7 @@
 }
 @logoColor = @{
   if (config.isDevelopment && config.isAdmin) {
-    "color-gray-medium-translucent"
+    "color-bluish-pink"
   } else if (config.isDevelopment) {
     "color-blue-medium"
   } else if (config.isAdmin) {


### PR DESCRIPTION
Remove the stripey background from admin mode and use different logo colors for: dev mode, production admin mode and dev admin mode