### PR TITLE
Don't have the bot try to DM itself as a fallback when no Slack profile is found

### DIFF
--- a/app/actors/ScheduledActor.scala
+++ b/app/actors/ScheduledActor.scala
@@ -46,7 +46,7 @@ class ScheduledActor @Inject()(
           }.getOrElse(DBIO.successful(None))
           _ <- maybeProfile.map { profile =>
             scheduled.updateNextTriggeredForAction(dataService).flatMap { _ =>
-              DBIO.from(scheduled.send(eventHandler, new SlackApiClient(profile.token), profile, services).recover {
+              DBIO.from(scheduled.send(eventHandler, new SlackApiClient(profile.token), profile, services, displayText).recover {
                 case t: Throwable => {
                   val user = scheduled.maybeUser.map { user =>
                     s"Ellipsis ID ${user.id} / Slack ID ${maybeSlackUserId.getOrElse("(unknown)")}"


### PR DESCRIPTION
With scheduled items, don't fallback to using the bot's slack profile if it's supposed to run in a direct message. Instead, log a warning and ignore the item.