### PR TITLE
Try harder to remove the initial emoji reaction to a message if somehow the future completes before the first request

### DIFF
--- a/app/utils/SlackMessageReactionHandler.scala
+++ b/app/utils/SlackMessageReactionHandler.scala
@@ -27,7 +27,11 @@ object SlackMessageReactionHandler {
       Thread.sleep(delayMilliseconds)
       if (!p.isCompleted) {
         client.addReactionToMessage(INITIAL_REACTION, channel, messageTs).map(_ => {
-          updateReactionProgress(p, client, channel, messageTs)
+          if (p.isCompleted) {
+            removeAll(client, channel, messageTs)
+          } else {
+            updateReactionProgress(p, client, channel, messageTs)
+          }
         })
         p.future.onComplete(_ => removeAll(client, channel, messageTs))
       }


### PR DESCRIPTION
Add another place where we possibly try to remove reactions if the future has completed between requesting to add the emoji reaction and that request completing.