### PR TITLE
Always show links to Github repos on the skills page

### DIFF
--- a/app/assets/frontend/behavior_list/behavior_group_info_panel.tsx
+++ b/app/assets/frontend/behavior_list/behavior_group_info_panel.tsx
@@ -7,7 +7,7 @@ import Formatter, {Timestamp} from '../lib/formatter';
 import SVGInstall from '../svg/install';
 import Sort from '../lib/sort';
 import autobind from '../lib/autobind';
-import {default as User, UserJson} from "../models/user";
+import User from "../models/user";
 
   // Note that performance reasons this component checks if properties have changed by hand in shouldComponentUpdate
   type Props = {


### PR DESCRIPTION
On the skills page, always show the linked Github repo if present, and simplify the "source" of the skill as being either: 1. published or 2. managed or 3. published/managed or 4. custom