### PR TITLE
Fix JSON problem with Slack conversation responses for DM channels

### DIFF
--- a/app/json/Formatting.scala
+++ b/app/json/Formatting.scala
@@ -198,6 +198,7 @@ object Formatting {
 
   lazy implicit val slackConversationTopicFormat: Format[SlackConversationTopic] = Json.format[SlackConversationTopic]
   lazy implicit val slackConversationPurposeFormat: Format[SlackConversationPurpose] = Json.format[SlackConversationPurpose]
+  lazy implicit val slackConversationLatestInfo: Format[SlackConversationLatestInfo] = Json.format[SlackConversationLatestInfo]
   lazy implicit val slackConversationFormat: Format[SlackConversation] = Json.format[SlackConversation]
 
 }

--- a/app/utils/SlackConversation.scala
+++ b/app/utils/SlackConversation.scala
@@ -12,6 +12,13 @@ case class SlackConversationPurpose(
                                      last_set: Long
                                    )
 
+case class SlackConversationLatestInfo(
+                                        `type`: Option[String],
+                                        user: Option[String],
+                                        text: Option[String],
+                                        ts: Option[String]
+                                      )
+
 case class SlackConversation(
                               id: String,
                               name: Option[String],
@@ -29,7 +36,7 @@ case class SlackConversation(
                               is_member: Option[Boolean],
                               is_private: Option[Boolean],
                               is_mpim: Option[Boolean],
-                              latest: Option[String],
+                              latest: Option[SlackConversationLatestInfo],
                               topic: Option[SlackConversationTopic],
                               purpose: Option[SlackConversationPurpose],
                               num_members: Option[Long],


### PR DESCRIPTION
"latest" is an object, not a string

This was causing `SlackChannels maybeIdFor` to return None for DM channel IDs, which in turn prevented Ellipsis API requests from completing.