### PR TITLE
Fix a mistake that prevented Lambda stack traces from showing up when…

### DIFF
--- a/app/models/behaviors/BotResult.scala
+++ b/app/models/behaviors/BotResult.scala
@@ -421,7 +421,7 @@ case class ExecutionErrorResult(
   }
 
   override val maybeLog: Option[String] = {
-    if (maybeAuthorLog.isEmpty && maybeError.isEmpty) {
+    if (maybeAuthorLog.isEmpty && maybeErrorLog.isEmpty) {
       None
     } else {
       Some(maybeAuthorLog.map(_ + "\n").getOrElse("") + maybeErrorLog.getOrElse(""))


### PR DESCRIPTION
… an async error happens, and nothing else was logged