### PR TITLE
Fixed a case where I was trying to query a behavior with the behaviorVersionId from the invocation token

### DIFF
--- a/app/models/behaviors/behaviorgroup/BehaviorGroupServiceImpl.scala
+++ b/app/models/behaviors/behaviorgroup/BehaviorGroupServiceImpl.scala
@@ -100,13 +100,13 @@ class BehaviorGroupServiceImpl @Inject() (
     for {
       maybeToken <- dataService.invocationTokens.findNotExpired(tokenId)
       maybeUser <- dataService.users.findForInvocationToken(tokenId)
-      maybeOriginatingBehavior <- (for {
+      maybeOriginatingBehaviorVersion <- (for {
         token <- maybeToken
         user <- maybeUser
       } yield {
-        dataService.behaviors.find(token.behaviorVersionId, user)
+        dataService.behaviorVersions.find(token.behaviorVersionId, user)
       }).getOrElse(Future.successful(None))
-    } yield maybeOriginatingBehavior.map(_.group)
+    } yield maybeOriginatingBehaviorVersion.map(_.group)
   }
 
   def merge(groups: Seq[BehaviorGroup], user: User): Future[BehaviorGroup] = {

--- a/app/models/behaviors/behaviorversion/BehaviorVersionService.scala
+++ b/app/models/behaviors/behaviorversion/BehaviorVersionService.scala
@@ -38,6 +38,8 @@ trait BehaviorVersionService {
 
   def findWithoutAccessCheck(id: String): Future[Option[BehaviorVersion]]
 
+  def find(id: String, user: User): Future[Option[BehaviorVersion]]
+
   def findForAction(behavior: Behavior, groupVersion: BehaviorGroupVersion): DBIO[Option[BehaviorVersion]]
 
   def findFor(behavior: Behavior, groupVersion: BehaviorGroupVersion): Future[Option[BehaviorVersion]]

--- a/app/models/behaviors/behaviorversion/BehaviorVersionServiceImpl.scala
+++ b/app/models/behaviors/behaviorversion/BehaviorVersionServiceImpl.scala
@@ -139,6 +139,21 @@ class BehaviorVersionServiceImpl @Inject() (
     dataService.run(action)
   }
 
+  def find(id: String, user: User): Future[Option[BehaviorVersion]] = {
+    for {
+      maybeBehaviorVersion <- findWithoutAccessCheck(id)
+      canAccess <- maybeBehaviorVersion.map { behaviorVersion =>
+        dataService.users.canAccess(user, behaviorVersion.behavior)
+      }.getOrElse(Future.successful(false))
+    } yield {
+      if (canAccess) {
+        maybeBehaviorVersion
+      } else {
+        None
+      }
+    }
+  }
+
   def uncompiledFindForBehaviorAndGroupVersionQuery(behaviorId: Rep[String], groupVersionId: Rep[String]) = {
     allWithGroupVersion.filter { case ((behaviorVersion, _), ((groupVersion, _), _)) => behaviorVersion
       .behaviorId === behaviorId && groupVersion.id === groupVersionId


### PR DESCRIPTION
- this broke the default storage api