### PR TITLE
Fix broken layout on skills page when setting the team time zone

### DIFF
--- a/app/assets/frontend/behavior_list/index.tsx
+++ b/app/assets/frontend/behavior_list/index.tsx
@@ -934,8 +934,8 @@ class BehaviorList extends React.Component<Props, State> {
     const hasUninstalledGroups = allUninstalled.length > 0;
     return (
       <div className="flex-row-cascade">
-        {this.props.notification}
         <FixedHeader onHeightChange={this.updateSearchHeaderHeight} marginTop={this.getMainHeaderHeight()} zIndexClassName="position-z-behind-scrim">
+          {this.props.notification}
           {this.renderSearch()}
         </FixedHeader>
         <div className="flex-row-cascade" style={this.getScrollableContainerStyle()}>


### PR DESCRIPTION
Fix layout of the notification about setting the time zone on the skills list page — it was hidden behind another fixed element making the page look broken