### PR TITLE
Fix AdminSkillErrorNotification so bot doesn't try to send itself a DM

### DIFF
--- a/app/models/behaviors/BotResult.scala
+++ b/app/models/behaviors/BotResult.scala
@@ -528,17 +528,17 @@ case class AdminSkillErrorNotificationResult(
     s" running action `$action` in skill `$skill` $skillLink"
   }.getOrElse("")
   lazy val text: String = {
-    val user = s"<@${originalResult.event.userIdForContext}>"
+    val userId = originalResult.event.userIdForContext
     s"""Error$description
        |
        |Team: $teamLink
-       |User: $user
+       |User: <@${userId}> (ID #${userId})
        |Result type: ${originalResult.resultType}
        |
      """.stripMargin
   }
 
-  lazy val maybeConversation: Option[Conversation] = originalResult.maybeConversation
+  lazy val maybeConversation: Option[Conversation] = None
   lazy val maybeBehaviorVersion: Option[BehaviorVersion] = originalResult.maybeBehaviorVersion
   override def maybeLogFile: Option[UploadFileSpec] = originalResult.maybeLogFile
   val forcePrivateResponse: Boolean = false


### PR DESCRIPTION
Don't set the conversation on AdminSkillErrorNotificationResult since it's irrelevant and interferes with which channel the message is delivered in. Also include the Slack user ID since we can't always see the linked user.