### PR TITLE
Remove intro/interruption-intro text from BotResults

### DIFF
--- a/app/actors/ConversationReminderActor.scala
+++ b/app/actors/ConversationReminderActor.scala
@@ -36,7 +36,7 @@ class ConversationReminderActor @Inject()(
         dataService.conversations.touchAction(convo).flatMap { _ =>
           convo.maybeRemindResultAction(services).flatMap { maybeResult =>
             maybeResult.map { result =>
-              services.botResultService.sendInAction(result, None, None).map(_ => true)
+              services.botResultService.sendInAction(result, None).map(_ => true)
             }.getOrElse(DBIO.successful(true))
           }
         }

--- a/app/controllers/APIController.scala
+++ b/app/controllers/APIController.scala
@@ -205,33 +205,13 @@ class APIController @Inject() (
 
   }
 
-  private def maybeIntroTextFor(event: Event, context: ApiMethodContext, isForInterruption: Boolean): Option[String] = {
-    val greeting = if (isForInterruption) {
-      "Meanwhile, "
-    } else {
-      s""":wave: Hi.
-       |
-       |""".stripMargin
-    }
-    if (context.isInvokedExternally) {
-      Some(s"""${greeting}I’ve been asked to run `${event.messageText}`.
-       |
-       |───
-       |""".stripMargin)
-    } else {
-      None
-    }
-  }
-
   private def runBehaviorFor(maybeEvent: Option[Event], context: ApiMethodContext) = {
     for {
       result <- maybeEvent.map { event =>
         for {
           result <- eventHandler.handle(event, None).map { results =>
             results.foreach { result =>
-              val maybeIntro = maybeIntroTextFor(event, context, isForInterruption = false)
-              val maybeInterruptionIntro = maybeIntroTextFor(event, context, isForInterruption = true)
-              botResultService.sendIn(result, None, maybeIntro, maybeInterruptionIntro).map { _ =>
+              botResultService.sendIn(result, None).map { _ =>
                 Logger.info(event.logTextFor(result, Some("in response to /api/post_message")))
               }
             }

--- a/app/models/behaviors/BotResultService.scala
+++ b/app/models/behaviors/BotResultService.scala
@@ -9,16 +9,12 @@ trait BotResultService {
 
   def sendInAction(
                     botResult: BotResult,
-                    maybeShouldUnfurl: Option[Boolean],
-                    maybeIntro: Option[String] = None,
-                    maybeInterruptionIntro: Option[String] = None
+                    maybeShouldUnfurl: Option[Boolean]
                   )(implicit actorSystem: ActorSystem): DBIO[Option[String]]
 
   def sendIn(
               botResult: BotResult,
-              maybeShouldUnfurl: Option[Boolean],
-              maybeIntro: Option[String] = None,
-              maybeInterruptionIntro: Option[String] = None
+              maybeShouldUnfurl: Option[Boolean]
             )(implicit actorSystem: ActorSystem): Future[Option[String]]
 
 }

--- a/test/controllers/APIControllerSpec.scala
+++ b/test/controllers/APIControllerSpec.scala
@@ -106,13 +106,7 @@ class APIControllerSpec extends PlaySpec with MockitoSugar {
     when(dataService.conversations.allOngoingFor(defaultSlackUserId, event.context, event.maybeChannel, event.maybeThreadId, team.id)).thenReturn(Future.successful(Seq()))
     when(eventHandler.handle(any[Event], org.mockito.Matchers.eq(None))).thenReturn(Future.successful(Seq(SimpleTextResult(event, None, "result", forcePrivateResponse = false))))
 
-    when(botResultService.sendIn(
-      any[BotResult],
-      any[Option[Boolean]],
-      any[Option[String]],
-      any[Option[String]]
-    )(any[ActorSystem])
-    ).thenReturn(Future.successful(Some(SlackTimestamp.now)))
+    when(botResultService.sendIn(any[BotResult], any[Option[Boolean]])(any[ActorSystem])).thenReturn(Future.successful(Some(SlackTimestamp.now)))
 
     token
   }


### PR DESCRIPTION
Remove the canned intro/interruption text from scheduled and API-triggered actions since it often appears too late. (Actions that run other actions or use "say" make such text pointless and strange.)