### PR TITLE
Don't log errors when there's a message_not_found error retrieving permalinks

### DIFF
--- a/app/services/slack/SlackApiService.scala
+++ b/app/services/slack/SlackApiService.scala
@@ -98,8 +98,15 @@ case class SlackApiClient(
     getResponseFor("chat.getPermalink", params).
       map(r => Some(extract[String](r, "permalink"))).
       recover {
+        case SlackApiError("message_not_found") => None // happens for simulated timestamps in RunEvents
         case SlackApiError(err) => {
-          Logger.error(s"Failed to retrieve permalink: $err")
+          Logger.error(
+            s"""
+               |Failed to retrieve permalink: $err
+               |
+               |Channel: $channel
+               |Message timestamp: $messageTs
+             """.stripMargin)
           None
         }
       }


### PR DESCRIPTION
- this can happen in the normal course because we make up timestamps for RunEvents sometimes (ie. when running scheduled actions)