### PR TITLE
Prevent onslaught of skill meta-data requests from one window

### DIFF
--- a/app/assets/frontend/behavior_editor/index.jsx
+++ b/app/assets/frontend/behavior_editor/index.jsx
@@ -1752,7 +1752,8 @@ const BehaviorEditor = React.createClass({
     window.document.addEventListener('keydown', this.onDocumentKeyDown, false);
     window.addEventListener('resize', this.checkMobileLayout, false);
     window.addEventListener('scroll', debounce(this.updateBehaviorScrollPosition, 500), false);
-    window.addEventListener('focus', this.checkForUpdates, false);
+    this.checkForUpdateTimer = null;
+    window.addEventListener('focus', () => this.checkForUpdatesLater(2000), false);
     this.checkForUpdatesLater();
     this.loadNodeModuleVersions();
     this.loadTestResults();
@@ -1785,12 +1786,13 @@ const BehaviorEditor = React.createClass({
               errorReachingServer: null
             }, this.resetNotificationsEventually);
           }
-          this.checkForUpdatesLater();
         })
         .catch((err) => {
           this.setState({
             errorReachingServer: err
           }, this.resetNotificationsEventually);
+        })
+        .finally(() => {
           this.checkForUpdatesLater();
         });
     } else {
@@ -1798,8 +1800,9 @@ const BehaviorEditor = React.createClass({
     }
   },
 
-  checkForUpdatesLater: function() {
-    setTimeout(this.checkForUpdates, 30000);
+  checkForUpdatesLater: function(overrideDuration) {
+    clearTimeout(this.checkForUpdateTimer);
+    this.checkForUpdateTimer = setTimeout(this.checkForUpdates, overrideDuration || 30000);
   },
 
   getInitialEnvVariables: function() {


### PR DESCRIPTION
When the skill editor window regains focus, make sure we clear any existing timers for checking for updates in the background, instead of adding a new timer every time. This prevents long-running windows from creating a huge pile of meta-data requests.

(Previously, every time you switch back to the window, a new parallel 30-second timer would be created in addition to any existing 30-second timers.)