### PR TITLE
Warn users if they've scheduled actions in a restricted/read-only channel

### DIFF
--- a/app/assets/frontend/models/schedule_channel.tsx
+++ b/app/assets/frontend/models/schedule_channel.tsx
@@ -8,7 +8,8 @@ export interface ScheduleChannelJson {
   isPrivateChannel: boolean,
   isPrivateGroup: boolean,
   isArchived: boolean,
-  isShared: boolean
+  isShared: boolean,
+  isReadOnly: boolean
 }
 
 export interface ScheduleChannelInterface extends ScheduleChannelJson {}
@@ -24,6 +25,7 @@ class ScheduleChannel implements ScheduleChannelInterface {
   readonly isPrivateGroup: boolean;
   readonly isArchived: boolean;
   readonly isShared: boolean;
+  readonly isReadOnly: boolean;
 
     constructor(props: ScheduleChannelInterface) {
       Object.defineProperties(this, {
@@ -36,7 +38,8 @@ class ScheduleChannel implements ScheduleChannelInterface {
         isPrivateChannel: { value: props.isPrivateChannel, enumerable: true },
         isPrivateGroup: { value: props.isPrivateGroup, enumerable: true },
         isArchived: { value: props.isArchived, enumerable: true },
-        isShared: { value: props.isShared, enumerable: true }
+        isShared: { value: props.isShared, enumerable: true },
+        isReadOnly: { value: props.isReadOnly, enumerable: true }
       });
     }
 

--- a/app/assets/frontend/scheduling/index.tsx
+++ b/app/assets/frontend/scheduling/index.tsx
@@ -59,6 +59,7 @@ type ScheduleGroup = {
   excludesBot: boolean,
   isArchived: boolean,
   isMissing: boolean,
+  isReadOnly: boolean,
   actions: Array<ScheduledAction>
 }
 
@@ -204,6 +205,7 @@ class Scheduling extends React.Component<Props, State> {
           excludesBot: Boolean(channel && !channel.isDm() && !channel.isBotMember),
           isArchived: Boolean(channel && channel.isArchived),
           isMissing: !channel,
+          isReadOnly: Boolean(channel && channel.isReadOnly),
           actions: []
         };
         group.actions.push(action);
@@ -385,7 +387,7 @@ class Scheduling extends React.Component<Props, State> {
     }
 
     renderGroupWarningIcon(group: ScheduleGroup) {
-      if (group.isArchived || group.excludesBot || group.isMissing) {
+      if (group.isArchived || group.excludesBot || group.isMissing || group.isReadOnly) {
         return (
           <span className="mls display-inline-block type-pink height-xl align-m"><SVGWarning/></span>
         );
@@ -404,13 +406,19 @@ class Scheduling extends React.Component<Props, State> {
       } else if (group.excludesBot) {
         return (
           <span className="type-s type-pink type-bold type-italic">
-            — Warning: Ellipsis must be invited to this channel for any scheduled action to run.
+            — Warning: The bot must be invited to this channel for any scheduled action to run.
           </span>
         );
       } else if (group.isMissing) {
         return (
           <span className="type-s type-pink type-bold type-italic">
             — Warning: No information about this channel was found. It may have been deleted.
+          </span>
+        );
+      } else if (group.isReadOnly) {
+        return (
+          <span className="type-s type-pink type-bold type-italic">
+            — Warning: The bot is restricted from posting to this channel by the admin.
           </span>
         );
       } else {

--- a/app/assets/frontend/scheduling/schedule_channel_editor.tsx
+++ b/app/assets/frontend/scheduling/schedule_channel_editor.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import Checkbox from '../form/checkbox';
 import Collapsible from '../shared_ui/collapsible';
 import SearchWithResults from '../form/search_with_results';
-import SVGCheckmark from '../svg/checkmark';
 import ChannelName from './channel_name';
 import ScheduledAction from '../models/scheduled_action';
 import ScheduleChannel from '../models/schedule_channel';
@@ -130,6 +129,12 @@ class ScheduleChannelEditor extends React.Component<Props, State> {
       return Boolean(channel && channel.isArchived);
     }
 
+    channelReadOnly(): boolean {
+      const channelId = this.props.scheduledAction.channel;
+      const channel = this.findChannelFor(channelId);
+      return Boolean(channel && channel.isReadOnly);
+    }
+
     botMissingFromChannel(): boolean {
       const channelId = this.props.scheduledAction.channel;
       if (channelId && this.props.slackBotUserId) {
@@ -184,6 +189,12 @@ class ScheduleChannelEditor extends React.Component<Props, State> {
         return (
           <span className="type-pink type-bold type-italic">
             Warning: The bot must be invited to this channel to run any action
+          </span>
+        );
+      } else if (this.channelReadOnly()) {
+        return (
+          <span className="type-pink type-bold type-italic">
+            Warning: The bot is restricted from posting to this channel by the admin
           </span>
         );
       } else if (!this.hasChannelList()) {

--- a/app/json/ScheduleChannelData.scala
+++ b/app/json/ScheduleChannelData.scala
@@ -11,5 +11,6 @@ case class ScheduleChannelData(
                                 isPrivateChannel: Boolean,
                                 isPrivateGroup: Boolean,
                                 isArchived: Boolean,
-                                isShared: Boolean
+                                isShared: Boolean,
+                                isReadOnly: Boolean
                               )

--- a/app/json/ScheduledActionsConfig.scala
+++ b/app/json/ScheduledActionsConfig.scala
@@ -56,7 +56,8 @@ object ScheduledActionsConfig {
         convo.isPrivateChannel,
         convo.isMpim,
         convo.isArchived,
-        convo.isShared
+        convo.isShared,
+        convo.isReadOnly
       )
       maybeIsPrivateMember.map { isPrivateMember =>
         if (convo.isVisibleToUserWhere(isPrivateMember, forceAdmin)) {

--- a/app/utils/SlackConversation.scala
+++ b/app/utils/SlackConversation.scala
@@ -35,6 +35,7 @@ case class SlackConversation(
                               is_org_shared: Option[Boolean],
                               is_member: Option[Boolean],
                               is_private: Option[Boolean],
+                              is_read_only: Option[Boolean],
                               is_mpim: Option[Boolean],
                               latest: Option[SlackConversationLatestInfo],
                               topic: Option[SlackConversationTopic],
@@ -50,6 +51,7 @@ case class SlackConversation(
   val isPublic: Boolean = !isPrivateChannel && !isGroup && !isIm && !isMpim
   val isArchived: Boolean = is_archived.exists(identity)
   val isShared: Boolean = is_ext_shared.exists(identity)
+  val isReadOnly: Boolean = is_read_only.exists(identity)
 
   val isBotMember: Boolean = is_member.exists(identity)
 
@@ -103,6 +105,7 @@ object SlackConversation {
     is_org_shared = None,
     is_member = None,
     is_private = None,
+    is_read_only = None,
     is_mpim = None,
     latest = None,
     topic = None,

--- a/app/utils/SlackMessageSender.scala
+++ b/app/utils/SlackMessageSender.scala
@@ -51,6 +51,10 @@ case class ChannelNotFoundException(channel: String, slackTeamId: String, userId
   def channelReason(channelIdOrLink: String) = s"The channel could not be found. It may have been deleted."
 }
 
+case class RestrictedFromChannel(channel: String, slackTeamId: String, userId: String, text: String) extends SlackMessageSenderChannelException {
+  def channelReason(channelIdOrLink: String) = s"The bot is restricted from posting to the channel ${channelIdOrLink} by the admin."
+}
+
 case class SlackMessageSenderException(underlying: Throwable, channel: String, slackTeamId: String, userId: String, text: String)
   extends Exception(
     s"""Bad response from Slack while sending a message to user $userId in channel $channel on team $slackTeamId
@@ -293,6 +297,7 @@ case class SlackMessageSender(
     case SlackApiError("is_archived") => throw ArchivedChannelException(channel, slackTeamId, user, text)
     case SlackApiError("channel_not_found") => throw ChannelNotFoundException(channel, slackTeamId, user, text)
     case SlackApiError("not_in_channel") => throw NotInvitedToChannelException(channel, slackTeamId, user, text)
+    case SlackApiError("restricted_action") => throw RestrictedFromChannel(channel, slackTeamId, user, text)
     case t: Throwable => throw SlackMessageSenderException(t, channel, slackTeamId, user, text)
   }
 }

--- a/test/assets/frontend/scheduling/scheduling_spec.tsx
+++ b/test/assets/frontend/scheduling/scheduling_spec.tsx
@@ -97,7 +97,8 @@ function newChannel(props?: Partial<ScheduleChannelInterface>) {
     isPrivateChannel: false,
     isPrivateGroup: false,
     isArchived: false,
-    isShared: false
+    isShared: false,
+    isReadOnly: false
   }, props));
 }
 


### PR DESCRIPTION
This can happen if a user schedules something in the #general/general-equivalent channel and it is restricted to admins only (as with Plenty's #announcements channel)