### PR TITLE
Fix add to slack to use the right profile parsing

### DIFF
--- a/app/models/accounts/slack/SlackProvider.scala
+++ b/app/models/accounts/slack/SlackProvider.scala
@@ -35,7 +35,8 @@ class SlackProvider(protected val httpLayer: HTTPLayer,
   )
 
   protected def buildProfile(authInfo: A): Future[SlackProfile] = {
-    if (authInfo.params.exists(_.get("scope").exists(_.split(",").contains("identity.basic")))) {
+    val scopes = authInfo.params.flatMap(_.get("scope").map(_.split(",")))
+    if (scopes.size == 1 && scopes.contains("identity.basic")) {
       httpLayer.url(urls("identity").format(authInfo.accessToken)).get().flatMap { response =>
         profileParser.parseForSignIn(response.json)
       }


### PR DESCRIPTION
Looks like the test for when to parse for install vs sign-in got broken at some point to always use the sign-in parsing logic. One symptom of this was to not set the enterprise ID on slack bot profiles.