### PR TITLE
Maintain the current thread when running the next action even if the preceding response type is not threaded

### DIFF
--- a/app/models/behaviors/BotResultServiceImpl.scala
+++ b/app/models/behaviors/BotResultServiceImpl.scala
@@ -1,16 +1,14 @@
 package models.behaviors
 
 import akka.actor.ActorSystem
-import com.google.common.util.concurrent.Futures.FutureCombiner
 import javax.inject.Inject
-import models.behaviors.behaviorversion.{BehaviorVersion, Normal, Private, Threaded}
+import models.behaviors.behaviorversion.BehaviorVersion
 import models.behaviors.events.{Event, EventHandler, SlackEventContext, SlackRunEvent}
 import play.api.{Configuration, Logger}
 import services.caching.CacheService
 import services.slack.SlackEventService
 import services.{DataService, DefaultServices}
 import slick.dbio.DBIO
-import utils.SlackTimestamp
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/models/behaviors/behaviorversion/BehaviorResponseType.scala
+++ b/app/models/behaviors/behaviorversion/BehaviorResponseType.scala
@@ -2,7 +2,6 @@ package models.behaviors.behaviorversion
 
 import models.behaviors.BotResult
 import models.behaviors.conversations.conversation.Conversation
-import models.behaviors.events.Event
 import utils.Enum
 
 object BehaviorResponseType extends Enum[BehaviorResponseType] {

--- a/test/models/BehaviorResponseTypeSpec.scala
+++ b/test/models/BehaviorResponseTypeSpec.scala
@@ -1,13 +1,12 @@
 package models
 
-import models.behaviors.{BotResult, DeveloperContext, SuccessResult}
 import models.behaviors.behaviorversion.{BehaviorVersion, Normal, Private, Threaded}
-import models.behaviors.conversations.InvokeBehaviorConversation
 import models.behaviors.conversations.conversation.Conversation
 import models.behaviors.events.Event
+import models.behaviors.{BotResult, DeveloperContext, SuccessResult}
 import org.mockito.Mockito._
-import org.scalatestplus.play.PlaySpec
 import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.{JsObject, JsString}
 
 class BehaviorResponseTypeSpec extends PlaySpec with MockitoSugar {


### PR DESCRIPTION
When Ellipsis is already in a thread, we should stay in that thread as we run any next action, even if the immediately-preceding result didn't specify a threaded response type (which may happen when you have action A that specifies a threaded response, that runs action B which is normal but occurs in the same thread, that then runs action C as a next action).

I can't think of a good reason for "next" actions to break the current threading (unless their results  specify private responses, but this change doesn't affect that).