### PR TITLE
When deleting skills, cascade deletes down…

### DIFF
--- a/app/models/behaviors/behaviorgroup/BehaviorGroupServiceImpl.scala
+++ b/app/models/behaviors/behaviorgroup/BehaviorGroupServiceImpl.scala
@@ -180,7 +180,10 @@ class BehaviorGroupServiceImpl @Inject() (
         dataService.behaviors.unlearn(ea)
       })
       deleted <- {
-        val action = rawFindQuery(group.id).delete
+        val action = for {
+          _ <- dataService.managedBehaviorGroups.deleteForAction(group)
+          deleted <- rawFindQuery(group.id).delete
+        } yield deleted
         dataService.run(action).map(_ => group)
       }
     } yield deleted

--- a/app/models/behaviors/behaviortestresult/BehaviorTestResultService.scala
+++ b/app/models/behaviors/behaviortestresult/BehaviorTestResultService.scala
@@ -2,6 +2,7 @@ package models.behaviors.behaviortestresult
 
 import akka.actor.ActorSystem
 import models.behaviors.behaviorversion.BehaviorVersion
+import slick.dbio.DBIO
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -10,4 +11,5 @@ trait BehaviorTestResultService {
   def ensureFor(behaviorVersion: BehaviorVersion)
                (implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[BehaviorTestResult]
 
+  def deleteForAction(behaviorVersion: BehaviorVersion): DBIO[Unit]
 }

--- a/app/models/behaviors/behaviortestresult/BehaviorTestResultServiceImpl.scala
+++ b/app/models/behaviors/behaviortestresult/BehaviorTestResultServiceImpl.scala
@@ -12,6 +12,7 @@ import models.behaviors.behaviorversion.BehaviorVersion
 import models.behaviors.events.TestEventContext
 import models.behaviors.testing.TestMessageEvent
 import services.{AWSLambdaService, DataService}
+import slick.dbio.DBIO
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -69,4 +70,7 @@ class BehaviorTestResultServiceImpl @Inject() (
     dataService.run(action)
   }
 
+  def deleteForAction(behaviorVersion: BehaviorVersion): DBIO[Unit] = {
+    findByBehaviorVersionQuery(behaviorVersion.id).delete.map(_ => Unit)
+  }
 }

--- a/app/models/behaviors/behaviorversion/BehaviorVersionServiceImpl.scala
+++ b/app/models/behaviors/behaviorversion/BehaviorVersionServiceImpl.scala
@@ -314,7 +314,10 @@ class BehaviorVersionServiceImpl @Inject() (
   }
 
   def delete(behaviorVersion: BehaviorVersion): Future[BehaviorVersion] = {
-    val action = all.filter(_.id === behaviorVersion.id).delete.map(_ => behaviorVersion)
+    val action = for {
+      _ <- defaultServices.dataService.behaviorTestResults.deleteForAction(behaviorVersion)
+      deletedBehaviorVersion <- all.filter(_.id === behaviorVersion.id).delete.map(_ => behaviorVersion)
+    } yield deletedBehaviorVersion
     dataService.run(action)
   }
 

--- a/app/models/behaviors/managedbehaviorgroup/ManagedBehaviorGroupService.scala
+++ b/app/models/behaviors/managedbehaviorgroup/ManagedBehaviorGroupService.scala
@@ -19,6 +19,8 @@ trait ManagedBehaviorGroupService {
 
   def ensureFor(group: BehaviorGroup, maybeContact: Option[User]): Future[ManagedBehaviorGroup]
 
+  def deleteForAction(group: BehaviorGroup): DBIO[Unit]
+
   def deleteFor(group: BehaviorGroup): Future[Unit]
 
 }

--- a/app/models/behaviors/managedbehaviorgroup/ManagedBehaviorGroupServiceImpl.scala
+++ b/app/models/behaviors/managedbehaviorgroup/ManagedBehaviorGroupServiceImpl.scala
@@ -69,9 +69,12 @@ class ManagedBehaviorGroupServiceImpl @Inject() (
     dataService.run(action)
   }
 
+  def deleteForAction(group: BehaviorGroup): DBIO[Unit] = {
+    findForQuery(group.id).delete.map(_ => {})
+  }
+
   def deleteFor(group: BehaviorGroup): Future[Unit] = {
-    val action = findForQuery(group.id).delete.map(_ => {})
-    dataService.run(action)
+    dataService.run(deleteForAction(group))
   }
 
 


### PR DESCRIPTION
…to behavior test results and managed behavior groups so we don't violate key constraints

Resolves #2748