### PR TITLE
Rationalize Slack/MS Teams event handling

### DIFF
--- a/app/models/behaviors/builtins/DisplayHelpBehavior.scala
+++ b/app/models/behaviors/builtins/DisplayHelpBehavior.scala
@@ -61,27 +61,26 @@ case class DisplayHelpBehavior(
     } else {
       Some("Click a skill to learn more, or try searching a different keyword.")
     }
+    val eventContext = event.eventContext
     val skillActions = resultsToShow.map(result => {
       val label = result.group.shortName
       val buttonValue = HelpGroupSearchValue(result.group.helpActionId, maybeHelpSearch).toString
-      SlackMessageActionButton(SHOW_BEHAVIOR_GROUP_HELP, label, buttonValue)
+      eventContext.messageActionButtonFor(SHOW_BEHAVIOR_GROUP_HELP, label, buttonValue)
     })
 
     val remainingGroupCount = resultsRemaining.length
     val actionList = if (remainingGroupCount > 0) {
       val label = if (remainingGroupCount == 1) { "1 more skill…" } else { s"$remainingGroupCount more skills…" }
-      skillActions :+ SlackMessageActionButton(SHOW_HELP_INDEX, label, endAt.toString, maybeStyle = Some("primary"))
+      skillActions :+ eventContext.messageActionButtonFor(SHOW_HELP_INDEX, label, endAt.toString, maybeStyle = Some("primary"))
     } else {
       skillActions
     }
-    val attachment = slack.SlackMessageAttachment(
-      maybeInstructions,
-      None,
-      if (startAt == 0) { Some("Skills") } else { None },
-      None,
-      Some(Color.PINK),
-      Some(SHOW_HELP_INDEX),
-      actionList
+    val attachment = eventContext.messageAttachmentFor(
+      maybeText = maybeInstructions,
+      maybeTitle = if (startAt == 0) { Some("Skills") } else { None },
+      maybeColor = Some(Color.PINK),
+      maybeCallbackId = Some(SHOW_HELP_INDEX),
+      actions = actionList
     )
     val attachments = if (startAt == 0) {
       Seq(generalHelpAttachment(botPrefix), attachment)
@@ -98,8 +97,8 @@ case class DisplayHelpBehavior(
      """.stripMargin
   }
 
-  def generalHelpAttachment(botPrefix: String): SlackMessageAttachment = {
-    SlackMessageAttachment(Some(generalHelpText(botPrefix: String)), None, Some("General"))
+  def generalHelpAttachment(botPrefix: String) = {
+    event.eventContext.messageAttachmentFor(maybeText = Some(generalHelpText(botPrefix: String)), maybeTitle = Some("General"))
   }
 
   def skillNameFor(result: HelpResult): String = {

--- a/app/models/behaviors/conversations/conversation/Conversation.scala
+++ b/app/models/behaviors/conversations/conversation/Conversation.scala
@@ -129,10 +129,11 @@ trait Conversation {
         respondAction(event, isReminding=true, services).map { result =>
           val intro = s"Hey <@$userIdForContext>, don’t forget, I’m still waiting for your answer to this:"
           val callbackId = stopConversationCallbackIdFor(event.eventContext.userIdForContext, Some(id))
-          val actionList = Seq(SlackMessageActionButton(callbackId, "Stop asking", id))
+          val eventContext = event.eventContext
+          val actionList = Seq(eventContext.messageActionButtonFor(callbackId, "Stop asking", id))
           val question = result.text
-          val attachments = SlackMessageAttachment(Some(question), None, None, None, None, Some(callbackId), actionList)
-          Some(TextWithAttachmentsResult(result.event, Some(this), intro, result.responseType, Seq(attachments)))
+          val attachment = eventContext.messageAttachmentFor(maybeText = Some(question), maybeCallbackId = Some(callbackId), actions = actionList)
+          Some(TextWithAttachmentsResult(result.event, Some(this), intro, result.responseType, Seq(attachment)))
         }
       }.getOrElse(DBIO.successful(None))
     }

--- a/app/models/behaviors/events/EventContext.scala
+++ b/app/models/behaviors/events/EventContext.scala
@@ -86,9 +86,22 @@ sealed trait EventContext {
   def reactionHandler(eventualResults: Future[Seq[BotResult]], maybeMessageTs: Option[String], services: DefaultServices)
                      (implicit ec: ExecutionContext, actorSystem: ActorSystem): Future[Seq[BotResult]]
 
-  def messageActionButtonFor(callbackId: String, label: String, property: String, value: String): MessageActionButtonType
+  def messageActionButtonFor(
+                              callbackId: String,
+                              label: String,
+                              value: String,
+                              maybeStyle: Option[String] = None
+                            ): MessageActionButtonType
 
-  def messageAttachmentFor(callbackId: String, actionList: Seq[MessageActionButtonType]): MessageAttachmentType
+  def messageAttachmentFor(
+                            maybeText: Option[String] = None,
+                            maybeUserDataList: Option[Set[MessageUserData]] = None,
+                            maybeTitle: Option[String] = None,
+                            maybeTitleLink: Option[String] = None,
+                            maybeColor: Option[String] = None,
+                            maybeCallbackId: Option[String] = None,
+                            actions: Seq[MessageActionButtonType] = Seq()
+                          ): MessageAttachmentType
 
 }
 
@@ -309,12 +322,25 @@ case class SlackEventContext(
     )
   }
 
-  def messageActionButtonFor(callbackId: String, label: String, property: String, value: String) = {
+  def messageActionButtonFor(
+                              callbackId: String,
+                              label: String,
+                              value: String,
+                              maybeStyle: Option[String] = None
+                            ) = {
     SlackMessageActionButton(callbackId, label, value)
   }
 
-  def messageAttachmentFor(callbackId: String, actionList: Seq[SlackMessageActionButton]) = {
-    SlackMessageAttachment(None, None, None, None, None, Some(callbackId), actionList)
+  def messageAttachmentFor(
+                            maybeText: Option[String] = None,
+                            maybeUserDataList: Option[Set[MessageUserData]] = None,
+                            maybeTitle: Option[String] = None,
+                            maybeTitleLink: Option[String] = None,
+                            maybeColor: Option[String] = None,
+                            maybeCallbackId: Option[String] = None,
+                            actions: Seq[SlackMessageActionButton] = Seq()
+                          ): SlackMessageAttachment = {
+    SlackMessageAttachment(maybeText, maybeUserDataList, maybeTitle, maybeTitleLink, maybeColor, maybeCallbackId, actions)
   }
 
 }
@@ -445,12 +471,25 @@ case class MSTeamsEventContext(
     eventualResults // TODO: this
   }
 
-  def messageActionButtonFor(callbackId: String, label: String, property: String, value: String) = {
-    MSTeamsMessageActionButton(callbackId, label, Json.obj(property -> value).toString())
+  def messageActionButtonFor(
+                              callbackId: String,
+                              label: String,
+                              value: String,
+                              maybeStyle: Option[String] = None
+                            ) = {
+    MSTeamsMessageActionButton(label, Json.obj(callbackId -> value).toString())
   }
 
-  def messageAttachmentFor(callbackId: String, actionList: Seq[MSTeamsMessageActionButton]) = {
-    MSTeamsMessageAttachment(None, None, None, None, None, Some(callbackId), actionList)
+  def messageAttachmentFor(
+                            maybeText: Option[String] = None,
+                            maybeUserDataList: Option[Set[MessageUserData]] = None,
+                            maybeTitle: Option[String] = None,
+                            maybeTitleLink: Option[String] = None,
+                            maybeColor: Option[String] = None,
+                            maybeCallbackId: Option[String] = None,
+                            actions: Seq[MSTeamsMessageActionButton] = Seq()
+                          ): MSTeamsMessageAttachment = {
+    MSTeamsMessageAttachment(maybeText, maybeUserDataList, maybeTitle, maybeTitleLink, maybeColor, maybeCallbackId, actions)
   }
 
 }
@@ -537,12 +576,25 @@ case class TestEventContext(
 
   // TODO: we may have some reason to not use Slack here (although this was the existing behavior)
 
-  def messageActionButtonFor(callbackId: String, label: String, property: String, value: String) = {
+  def messageActionButtonFor(
+                              callbackId: String,
+                              label: String,
+                              value: String,
+                              maybeStyle: Option[String] = None
+                            ) = {
     SlackMessageActionButton(callbackId, label, value)
   }
 
-  def messageAttachmentFor(callbackId: String, actionList: Seq[SlackMessageActionButton]) = {
-    SlackMessageAttachment(None, None, None, None, None, Some(callbackId), actionList)
+  def messageAttachmentFor(
+                            maybeText: Option[String] = None,
+                            maybeUserDataList: Option[Set[MessageUserData]] = None,
+                            maybeTitle: Option[String] = None,
+                            maybeTitleLink: Option[String] = None,
+                            maybeColor: Option[String] = None,
+                            maybeCallbackId: Option[String] = None,
+                            actions: Seq[SlackMessageActionButton] = Seq()
+                          ): SlackMessageAttachment = {
+    SlackMessageAttachment(maybeText, maybeUserDataList, maybeTitle, maybeTitleLink, maybeColor, maybeCallbackId, actions)
   }
 
 }

--- a/app/models/behaviors/events/MessageActionButton.scala
+++ b/app/models/behaviors/events/MessageActionButton.scala
@@ -1,7 +1,6 @@
 package models.behaviors.events
 
 trait MessageActionButton {
-  val name: String
   val text: String
   val value: String
 }

--- a/app/models/behaviors/events/ms_teams/MSTeamsMessageActionButton.scala
+++ b/app/models/behaviors/events/ms_teams/MSTeamsMessageActionButton.scala
@@ -6,7 +6,6 @@ import play.api.libs.json.{JsString, JsValue, Json}
 import services.ms_teams.apiModels.CardAction
 
 case class MSTeamsMessageActionButton(
-                                       name: String,
                                        text: String,
                                        value: String,
                                        maybeStyle: Option[String] = None

--- a/app/models/behaviors/events/ms_teams/MSTeamsMessageAttachment.scala
+++ b/app/models/behaviors/events/ms_teams/MSTeamsMessageAttachment.scala
@@ -4,8 +4,8 @@ import models.behaviors.events.{MessageAttachment, MessageUserData}
 import services.ms_teams.apiModels.{AdaptiveCard, ContentAttachment}
 
 case class MSTeamsMessageAttachment(
-                                   maybeText: Option[String],
-                                   maybeUserDataList: Option[Set[MessageUserData]],
+                                   maybeText: Option[String] = None,
+                                   maybeUserDataList: Option[Set[MessageUserData]] = None,
                                    maybeTitle: Option[String] = None,
                                    maybeTitleLink: Option[String] = None,
                                    maybeColor: Option[String] = None,

--- a/app/models/behaviors/events/slack/SlackMessageAttachment.scala
+++ b/app/models/behaviors/events/slack/SlackMessageAttachment.scala
@@ -2,11 +2,11 @@ package models.behaviors.events.slack
 
 import models.SlackMessageFormatter
 import models.behaviors.events.{MessageAttachment, MessageUserData}
-import services.slack.apiModels.{ActionField, Attachment}
+import services.slack.apiModels.Attachment
 
 case class SlackMessageAttachment(
-                                   maybeText: Option[String],
-                                   maybeUserDataList: Option[Set[MessageUserData]],
+                                   maybeText: Option[String] = None,
+                                   maybeUserDataList: Option[Set[MessageUserData]] = None,
                                    maybeTitle: Option[String] = None,
                                    maybeTitleLink: Option[String] = None,
                                    maybeColor: Option[String] = None,

--- a/app/services/ms_teams/apiModels/ActivityInfo.scala
+++ b/app/services/ms_teams/apiModels/ActivityInfo.scala
@@ -1,19 +1,12 @@
 package services.ms_teams.apiModels
 
-import models.behaviors.ActionChoice
-
 case class ActivityInfo(
-                         activityType: String,
                          id: String,
-                         timestamp: String,
                          serviceUrl: String,
-                         channelId: String,
                          from: MessageParticipantInfo,
                          conversation: ConversationInfo,
                          recipient: MessageParticipantInfo,
-                         textFormat: Option[String],
                          text: Option[String],
-                         maybeActionChoice: Option[ActionChoice],
                          channelData: ChannelDataInfo
                        ) {
   val responseUrl: String = s"$serviceUrl/v3/conversations/${conversation.id}/activities/${id}"

--- a/app/utils/MSTeamsMessageSender.scala
+++ b/app/utils/MSTeamsMessageSender.scala
@@ -7,7 +7,6 @@ import models.behaviors.conversations.conversation.Conversation
 import models.behaviors.events.MessageActionConstants._
 import models.behaviors.events._
 import models.behaviors.events.ms_teams._
-import models.behaviors.events.slack.SlackMessageAttachment
 import models.behaviors.{ActionChoice, DeveloperContext}
 import play.api.libs.json.Json
 import services.DefaultServices
@@ -59,22 +58,18 @@ case class MSTeamsMessageSender(
       Seq()
     } else {
       val actionList = choices.zipWithIndex.map { case(ea, i) =>
-        val value = Json.toJson(ea).toString()
+        val value = Json.obj(ACTION_CHOICE -> Json.toJson(ea)).toString()
         val valueToUse = if (value.length > MSTeamsMessageSender.MAX_ACTION_VALUE_CHARS) {
           services.cacheService.cacheSlackActionValue(value)
         } else {
           value
         }
-        MSTeamsMessageActionButton(ACTION_CHOICE, ea.label, valueToUse)
+        MSTeamsMessageActionButton(ea.label, valueToUse)
       }
       Seq(MSTeamsMessageAttachment(
-        None,
-        None,
-        None,
-        None,
-        Some(Color.BLUE_LIGHTER),
-        Some(ACTION_CHOICES),
-        actionList
+        maybeColor = Some(Color.BLUE_LIGHTER),
+        maybeCallbackId = Some(ACTION_CHOICES),
+        actions = actionList
       ))
     }
   }


### PR DESCRIPTION
- start routing more attachment creation through platform-specific event contexts
- stop using play Forms stuff in MSTeamsController and instead use json formatters