### PR TITLE
Add a migration to cascade deletes that should occur when deleting a skill

### DIFF
--- a/conf/evolutions/default/144.sql
+++ b/conf/evolutions/default/144.sql
@@ -1,5 +1,7 @@
 # --- !Ups
 
+BEGIN;
+
 ALTER TABLE behavior_test_results
 DROP CONSTRAINT behavior_test_results_behavior_version_id_fkey,
 ADD CONSTRAINT behavior_test_results_behavior_version_id_fkey
@@ -13,9 +15,13 @@ ADD CONSTRAINT managed_behavior_groups_group_id_fkey
   FOREIGN KEY(group_id)
   REFERENCES behavior_groups(id)
   ON DELETE CASCADE;
+
+COMMIT;
 
 # --- !Downs
 
+BEGIN;
+
 ALTER TABLE behavior_test_results
 DROP CONSTRAINT behavior_test_results_behavior_version_id_fkey,
 ADD CONSTRAINT behavior_test_results_behavior_version_id_fkey
@@ -29,3 +35,5 @@ ADD CONSTRAINT managed_behavior_groups_group_id_fkey
   FOREIGN KEY(group_id)
   REFERENCES behavior_groups(id)
   ON DELETE NO ACTION;
+
+COMMIT;


### PR DESCRIPTION
Resolves #2748 

Cascade deletes:
- from behavior groups to managed behavior groups
- and from behavior versions to behavior test results
