### PR TITLE
Some event context fixes/improvements

### DIFF
--- a/app/assets/frontend/code_editor/definitions/ellipsis.ts
+++ b/app/assets/frontend/code_editor/definitions/ellipsis.ts
@@ -127,8 +127,11 @@ declare namespace ellipsis {
     /** The text of the message that preceded this action */
     text: string
     
-    /** The name of the message medium, e.g. "slack" */
+    /** The name of the message medium, e.g. "slack" or "msTeams" */
     medium: string
+
+    /** The human-readable description of the message medium, e.g. "Slack" or "Microsoft Teams" */
+    mediumDescription: string
     
     /** The channel ID for where this message originated, if applicable */
     channel?: string

--- a/app/models/accounts/BotProfile.scala
+++ b/app/models/accounts/BotProfile.scala
@@ -16,12 +16,19 @@ object BotContext extends Enum[BotContext] {
   val values = List(SlackContext, MSTeamsContext)
 }
 
-sealed trait BotContext extends BotContext.Value
+sealed trait BotContext extends BotContext.Value {
+  val name: String
+  val description: String
+}
 
 case object SlackContext extends BotContext {
-  override def toString: String = "slack"
+  override val name: String = "slack"
+  override val description: String = "Slack"
+  override def toString: String = name
 }
 
 case object MSTeamsContext extends BotContext {
-  override def toString: String = "ms_teams"
+  override val name: String = "ms_teams"
+  override val description: String = "Microsoft Teams"
+  override def toString: String = name
 }

--- a/app/models/behaviors/BotResult.scala
+++ b/app/models/behaviors/BotResult.scala
@@ -281,7 +281,8 @@ case class SuccessResult(
 
   override def maybeChoicesAction(dataService: DataService)(implicit ec: ExecutionContext): DBIO[Option[Seq[ActionChoice]]] = {
     event.ensureUserAction(dataService).map { user =>
-      (payloadJson \ "choices").asOpt[Seq[SkillCodeActionChoice]].map { choices =>
+      val maybeChoices = (payloadJson \ "choices").asOpt[Seq[SkillCodeActionChoice]]
+      maybeChoices.map { choices =>
         choices.map(_.toActionChoiceWith(user, behaviorVersion))
       }
     }

--- a/app/models/behaviors/UserInfo.scala
+++ b/app/models/behaviors/UserInfo.scala
@@ -31,6 +31,7 @@ case class LinkedInfo(externalSystem: String, accessToken: String) {
 case class MessageInfo(
                         text: String,
                         medium: String,
+                        mediumDescription: String,
                         channel: Option[String],
                         thread: Option[String],
                         userId: String,
@@ -54,6 +55,7 @@ object MessageInfo {
       MessageInfo(
         event.messageText,
         event.eventContext.name,
+        event.eventContext.description,
         event.maybeChannel,
         event.maybeThreadId,
         event.eventContext.userIdForContext,

--- a/app/models/behaviors/events/EventContext.scala
+++ b/app/models/behaviors/events/EventContext.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import com.mohiva.play.silhouette.api.LoginInfo
 import json.Formatting._
 import json.SlackUserData
+import models.accounts.{MSTeamsContext, SlackContext}
 import models.accounts.ms_teams.botprofile.MSTeamsBotProfile
 import models.accounts.slack.botprofile.SlackBotProfile
 import models.accounts.user.User
@@ -37,6 +38,7 @@ sealed trait EventContext {
   val isDirectMessage: Boolean
   val maybeChannel: Option[String]
   val name: String
+  val description: String
 
   val usesTextInputs: Boolean = false
 
@@ -145,7 +147,8 @@ case class SlackEventContext(
   }
 
   val ellipsisTeamId: String = profile.teamId
-  lazy val name: String = Conversation.SLACK_CONTEXT
+  val name: String = SlackContext.name
+  val description: String = SlackContext.description
   val maybeChannel: Option[String] = Some(channel)
   val teamIdForContext: String = profile.slackTeamId
   val botUserId: String = profile.userId
@@ -397,7 +400,8 @@ case class MSTeamsEventContext(
   override type MenuType = MSTeamsMessageMenu
   override type MenuItemType = MSTeamsMessageMenuItem
 
-  val name: String = Conversation.MS_TEAMS_CONTEXT
+  val name: String = MSTeamsContext.name
+  val description: String = MSTeamsContext.description
   val userIdForContext: String = info.from.id
   val teamIdForContext: String = profile.teamIdForContext
   val ellipsisTeamId: String = profile.teamId
@@ -578,6 +582,7 @@ case class TestEventContext(
   override type MenuItemType = SlackMessageMenuItem
 
   val name = "test"
+  val description = "Test"
   val isPublicChannel: Boolean = false
   val isDirectMessage: Boolean = false
   val maybeChannel: Option[String] = None

--- a/app/models/behaviors/events/slack/SlackRunEvent.scala
+++ b/app/models/behaviors/events/slack/SlackRunEvent.scala
@@ -33,4 +33,10 @@ case class SlackRunEvent(
     eventContext.reactionHandler(eventualResults, maybeTriggeringMessageTs, services)
   }
 
+  override def maybePermalinkFor(services: DefaultServices)(implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[Option[String]] = {
+    maybeTriggeringMessageTs.map { ts =>
+      eventContext.maybePermalinkFor(ts, services)
+    }.getOrElse(Future.successful(None))
+  }
+
 }


### PR DESCRIPTION
- Ensure permalink is set on SlackRunEventwhen it originates from a prior message event
- Add a human-readable description of the medium to the ellipsis object, e.g. "Slack" or "Microsoft Teams"
