### PR TITLE
Fix reading file attachments from MS Teams events

### DIFF
--- a/app/models/behaviors/events/ms_teams/MSTeamsMessageAttachment.scala
+++ b/app/models/behaviors/events/ms_teams/MSTeamsMessageAttachment.scala
@@ -1,7 +1,7 @@
 package models.behaviors.events.ms_teams
 
 import models.behaviors.events.{MessageAttachment, MessageUserData}
-import services.ms_teams.apiModels.{AdaptiveCard, CardElement, ContentAttachment, TextBlock}
+import services.ms_teams.apiModels.{AdaptiveCard, CardElement, Attachment, TextBlock}
 
 case class MSTeamsMessageAttachment(
                                    maybeText: Option[String] = None,
@@ -16,9 +16,9 @@ case class MSTeamsMessageAttachment(
   val bodyElements: Seq[CardElement] = maybeText.map(t => TextBlock(t)).toSeq ++ actions.flatMap(_.bodyElements)
   val actionElements: Seq[CardElement] = actions.flatMap(_.actionElements)
 
-  val underlying = ContentAttachment(
+  val underlying = Attachment(
     "application/vnd.microsoft.card.adaptive",
-    AdaptiveCard(bodyElements, actionElements),
+    Some(AdaptiveCard(bodyElements, actionElements)),
     contentUrl = None,
     name = None
   )

--- a/app/models/behaviors/events/ms_teams/MSTeamsMessageEvent.scala
+++ b/app/models/behaviors/events/ms_teams/MSTeamsMessageEvent.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import models.accounts.ms_teams.botprofile.MSTeamsBotProfile
 import models.behaviors.conversations.conversation.Conversation
 import models.behaviors.events._
-import services.ms_teams.apiModels.{Attachment, ContentAttachment, File}
+import services.ms_teams.apiModels.{Attachment, File}
 import services.{DataService, DefaultServices}
 import utils.FileReference
 
@@ -30,7 +30,7 @@ case class MSTeamsMessageEvent(
   val eventType: EventType = EventType.chat
 
   val maybeFile: Option[FileReference] = attachments.flatMap {
-    case ContentAttachment(_, f: File, _, _) => Some(f)
+    case Attachment(_, Some(f: File), _, _) => Some(f)
     case _ => None
   }.headOption
 

--- a/app/services/ms_teams/apiModels/Attachment.scala
+++ b/app/services/ms_teams/apiModels/Attachment.scala
@@ -1,20 +1,10 @@
 package services.ms_teams.apiModels
 
-sealed trait Attachment {
-  val contentType: String
-  val isFile: Boolean = false
-}
-
-case class LinkAttachment(
+case class Attachment(
                        contentType: String,
-                       contentUrl: String
-                     ) extends Attachment
-
-case class ContentAttachment(
-                           contentType: String,
-                           content: AttachmentContent,
-                           contentUrl: Option[String],
-                           name: Option[String]
-                         ) extends Attachment {
-  override val isFile: Boolean = contentType == "application/vnd.microsoft.teams.file.download.info"
+                       content: Option[AttachmentContent],
+                       contentUrl: Option[String],
+                       name: Option[String]
+                     ) {
+  val isFile: Boolean = contentType == "application/vnd.microsoft.teams.file.download.info"
 }

--- a/app/services/ms_teams/apiModels/Formatting.scala
+++ b/app/services/ms_teams/apiModels/Formatting.scala
@@ -79,10 +79,8 @@ object Formatting {
 
   lazy implicit val attachmentContentFormat: Format[AttachmentContent] = Jsonx.formatSealedWithFallback[AttachmentContent, UnknownAttachmentContent]
   lazy implicit val cardElementFormat: Format[CardElement] = Jsonx.formatSealed[CardElement]
-  lazy implicit val contentAttachmentFormat: Format[ContentAttachment] = Jsonx.formatCaseClass[ContentAttachment]
 
-  lazy implicit val linkAttachmentFormat: Format[LinkAttachment] = Jsonx.formatCaseClass[LinkAttachment]
-  lazy implicit val attachmentFormat: Format[Attachment] = Jsonx.formatSealed[Attachment]
+  lazy implicit val attachmentFormat: Format[Attachment] = Json.format[Attachment]
 
   lazy implicit val applicationFormat: Format[Application] = Json.format[Application]
 


### PR DESCRIPTION
- previously it was possible for a file attachment to be parsed as a link attachment (unpredictably no less). made this no longer possible