### PR TITLE
Somewhat more gracefully handle html content in MS Teams messages:

### DIFF
--- a/app/services/ms_teams/apiModels/Attachment.scala
+++ b/app/services/ms_teams/apiModels/Attachment.scala
@@ -7,4 +7,5 @@ case class Attachment(
                        name: Option[String]
                      ) {
   val isFile: Boolean = contentType == "application/vnd.microsoft.teams.file.download.info"
+  val isHtml: Boolean = contentType == "text/html"
 }


### PR DESCRIPTION
- strip out <div> tags
- replace `<img alt="foo"/>` with just the alt text, which gives us emoji
- i'm sure there are many cases this handles poorly