### PR TITLE
Fix the order of inputs on the skill editor

### DIFF
--- a/app/assets/frontend/behavior_editor/index.tsx
+++ b/app/assets/frontend/behavior_editor/index.tsx
@@ -357,9 +357,15 @@ class BehaviorEditor extends React.Component<Props, State> {
 
   getInputs(): Array<Input> {
     const inputIds = this.getInputIds();
-    return this.getBehaviorGroup().getInputs().filter((input) => {
-      return input.inputId ? inputIds.includes(input.inputId) : false;
+    const allInputs = this.getBehaviorGroup().getInputs();
+    const inputs: Array<Input> = [];
+    inputIds.forEach((inputId) => {
+      const input = allInputs.find((input) => input.inputId === inputId);
+      if (input) {
+        inputs.push(input);
+      }
     });
+    return inputs;
   }
 
   getFirstBehaviorInputName(): string {

--- a/app/assets/frontend/models/oauth.tsx
+++ b/app/assets/frontend/models/oauth.tsx
@@ -144,7 +144,7 @@ export class OAuthApplicationRef extends ApiConfigRef implements OAuthApplicatio
     return RequiredOAuthApplication.editorFor(editor);
   }
 
-  static fromJson(props: { id: string, displayName: string, apiId: string, scope: string }): OAuthApplicationRef {
+  static fromJson(props: OAuthApplicationRefJson): OAuthApplicationRef {
     return new OAuthApplicationRef(props.id, props.displayName, props.apiId, props.scope);
   }
 }

--- a/test/assets/frontend/behavior_editor/behavior_editor_spec.tsx
+++ b/test/assets/frontend/behavior_editor/behavior_editor_spec.tsx
@@ -11,6 +11,9 @@ import {OAuthApplicationRef} from '../../../../app/assets/frontend/models/oauth'
 import {SimpleTokenApiRef} from '../../../../app/assets/frontend/models/simple_token';
 import Page, {PageRequiredProps} from "../../../../app/assets/frontend/shared_ui/page";
 import BehaviorResponseType from "../../../../app/assets/frontend/models/behavior_response_type";
+import Input from "../../../../app/assets/frontend/models/input";
+import ResponseTemplate from "../../../../app/assets/frontend/models/response_template";
+import DataTypeConfig from "../../../../app/assets/frontend/models/data_type_config";
 
 jest.mock('../../../../app/assets/frontend/behavior_editor/code_configuration', () => {
   return {
@@ -48,7 +51,7 @@ describe('BehaviorEditor', () => {
   const normalResponseType = "Normal";
   const normalResponseTypeJson = { id: normalResponseType, displayString: "Respond normally" };
   const privateResponseType = "Private";
-  const groupJson: BehaviorGroupJson = {
+  const defaultGroup: BehaviorGroup = BehaviorGroup.fromJson({
     teamId: "1",
     id: '1',
     actionInputs: [],
@@ -85,15 +88,15 @@ describe('BehaviorEditor', () => {
       repo: "ellipsis",
       currentBranch: "master"
     }
-  };
-  const defaultConfig = Object.freeze({
+  });
+  const defaultConfig: BehaviorEditorProps = Object.freeze({
     teamId: "A",
     "isAdmin": false,
     "isLinkedToGithub": false,
-    group: groupJson,
+    group: defaultGroup,
     selectedId: "1",
     csrfToken: "2",
-    envVariables: [ { name: "HOT_DOG" } ],
+    envVariables: [ { name: "HOT_DOG", isAlreadySavedWithValue: true } ],
     builtinParamTypes: [{
       id: 'Text',
       name: 'Text',
@@ -104,31 +107,33 @@ describe('BehaviorEditor', () => {
       name: 'Number',
       needsConfig: false,
       exportId: 'Number'
-    }],
+    }].map(ParamType.fromJson),
     "awsConfigs": [{
       "id": "aws",
       "displayName": "main",
       "accessKeyId": "a",
       "secretAccessKey": "b",
       "region": "c"
-    }],
+    }].map(AWSConfigRef.fromJson),
     "oauthApplications": [{
+      "id": "OAuthNumber1",
       "apiId": "7gK5ysNxSjSa9BzfB44yAg",
-      "applicationId": "R1-v9CKHTEmaUvgei-GmIg",
       "scope": "read",
-      "displayName": "Trello"
+      "displayName": "Trello",
     }, {
+      "id": "OAuthNumber2",
       "apiId": "RdG2Wm5DR0m2_4FZXf-yKA",
-      "applicationId": "Yy1QcMTcT96tZZmUoYLroQ",
       "scope": "https://www.googleapis.com/auth/calendar",
-      "displayName": "Google Calendar"
-    }],
+      "displayName": "Google Calendar",
+      recommendedScope: ""
+    }].map(OAuthApplicationRef.fromJson),
     "oauthApis": [{
       "apiId": "7gK5ysNxSjSa9BzfB44yAg",
       "name": "Trello",
       "newApplicationUrl": "https://trello.com/app-key",
       "scopeDocumentationUrl": "",
-      "isOAuth1": true
+      "isOAuth1": true,
+      requiresAuth: false
     }, {
       "apiId": "RdG2Wm5DR0m2_4FZXf-yKA",
       "name": "Google",
@@ -138,11 +143,10 @@ describe('BehaviorEditor', () => {
       "isOAuth1": false
     }],
     "simpleTokenApis": [{
-      "apiId": "pivotal-tracker",
+      "id": "pivotal-tracker",
       "displayName": "Pivotal Tracker",
-      "tokenUrl": "https://www.pivotaltracker.com/profile",
       "logoImageUrl": "/assets/images/logos/pivotal_tracker.png"
-    }],
+    }].map(SimpleTokenApiRef.fromJson),
     "linkedOAuthApplicationIds": ["R1-v9CKHTEmaUvgei-GmIg", "Yy1QcMTcT96tZZmUoYLroQ"],
     onSave: jest.fn(),
     savedAnswers: [],
@@ -150,10 +154,16 @@ describe('BehaviorEditor', () => {
     userId: "1",
     onLinkGithubRepo: jest.fn(),
     onUpdateFromGithub: jest.fn(),
-    "possibleResponseTypes": [normalResponseTypeJson]
+    onLoad: null,
+    onDeploy: jest.fn(),
+    showVersions: false,
+    lastDeployTimestamp: null,
+    slackTeamId: "T1",
+    botName: "TestBot",
+    possibleResponseTypes: [normalResponseTypeJson].map(BehaviorResponseType.fromProps)
   });
 
-  const newGroupJson: BehaviorGroupJson = {
+  const newGroup: BehaviorGroup = BehaviorGroup.fromJson({
     "teamId": "B",
     "actionInputs": [],
     "dataTypeInputs": [],
@@ -175,14 +185,14 @@ describe('BehaviorEditor', () => {
     "createdAt": "2017-09-15T11:58:07.36-04:00",
     "author": { "id": "3", userName: "attaboy" },
     isManaged: false
-  };
+  });
 
   const newSkillConfig: BehaviorEditorProps = Object.freeze({
     "containerId": "editorContainer",
     "csrfToken": "1234",
     "isAdmin": false,
     "isLinkedToGithub": false,
-    "group": BehaviorGroup.fromJson(newGroupJson),
+    "group": newGroup,
     "builtinParamTypes": [{
       "id": "Text",
       "exportId": "Text",
@@ -266,25 +276,15 @@ describe('BehaviorEditor', () => {
     possibleResponseTypes: [normalResponseTypeJson].map(BehaviorResponseType.fromProps)
   });
 
-  let editorConfig;
-  let firstBehavior: BehaviorVersionJson;
+  let editorConfig: BehaviorEditorProps;
+  let firstBehavior: BehaviorVersion;
 
   beforeEach(function() {
     editorConfig = Object.assign({}, defaultConfig);
-    firstBehavior = editorConfig.group.behaviorVersions[0];
   });
 
   function createEditor(config: BehaviorEditorProps): BehaviorEditor {
-    const props: BehaviorEditorProps & PageRequiredProps = Object.assign({}, Page.requiredPropDefaults(), config, {
-      group: BehaviorGroup.fromJson(config.group),
-      awsConfigs: config.awsConfigs.map(AWSConfigRef.fromJson),
-      oauthApplications: config.oauthApplications.map(OAuthApplicationRef.fromJson),
-      simpleTokenApis: config.simpleTokenApis.map(SimpleTokenApiRef.fromJson),
-      builtinParamTypes: config.builtinParamTypes.map(ParamType.fromJson),
-      onDeploy: jest.fn(),
-      botName: "TestBot",
-      possibleResponseTypes: [normalResponseTypeJson]
-    });
+    const props: BehaviorEditorProps & PageRequiredProps = Object.assign({}, Page.requiredPropDefaults(), config);
     return TestUtils.renderIntoDocument(
       <BehaviorEditor {...props} />
     ) as BehaviorEditor;
@@ -292,65 +292,74 @@ describe('BehaviorEditor', () => {
 
   describe('getFunctionBody', () => {
     it('returns the defined function', () => {
-      firstBehavior.functionBody = 'return;';
+      editorConfig.group = editorConfig.group.behaviorVersions[0].buildUpdatedGroupFor(editorConfig.group, {
+        functionBody: 'return;'
+      });
       let editor = createEditor(editorConfig);
       expect(editor.getFunctionBody()).toEqual('return;');
     });
 
     it('returns a string even when no function is defined', () => {
-      delete firstBehavior.functionBody;
+      editorConfig.group = editorConfig.group.behaviorVersions[0].buildUpdatedGroupFor(editorConfig.group, {
+        functionBody: undefined
+      });
       let editor = createEditor(editorConfig);
       expect(editor.getFunctionBody()).toEqual("");
     });
   });
 
   describe('getInputs', () => {
-    it('returns the defined parameters', () => {
-      editorConfig.group.actionInputs = [{
-        name: 'clown',
-        question: 'what drives the car?',
-        paramType: editorConfig.builtinParamTypes[0],
-        isSavedForTeam: false,
-        isSavedForUser: true,
-        inputId: "abcd1234",
-        exportId: null
-      }];
-      firstBehavior.inputIds = editorConfig.group.actionInputs.map(ea => ea.inputId);
-      let editor = createEditor(editorConfig);
-      expect(editor.getInputs()).toMatchObject(editorConfig.group.actionInputs);
-    });
-
-    it('returns an array even when no params are defined', () => {
-      delete firstBehavior.inputIds;
-      let editor = createEditor(editorConfig);
-      expect(editor.getInputs()).toEqual([]);
+    it('returns inputs in the order of the input IDs', () => {
+      editorConfig.group = editorConfig.group.clone({
+        actionInputs: [{
+          name: "thing1",
+          question: "What is thing 1?",
+          paramType: editorConfig.builtinParamTypes[0],
+          isSavedForTeam: false,
+          isSavedForUser: false,
+          inputId: "12345"
+        }, {
+          name: "thing2",
+          question: "What is thing 2?",
+          paramType: editorConfig.builtinParamTypes[1],
+          isSavedForTeam: false,
+          isSavedForUser: false,
+          inputId: "54321"
+        }].map(Input.fromJson),
+        behaviorVersions: [editorConfig.group.behaviorVersions[0].clone({
+          inputIds: ["54321", "12345"]
+        })]
+      });
+      const editor = createEditor(editorConfig);
+      const inputs = editor.getInputs();
+      expect(inputs[0].inputId).toBe("54321");
+      expect(inputs[1].inputId).toBe("12345");
     });
   });
 
   describe('getBehaviorTemplate', () => {
     it('returns the template when it’s non-empty', () => {
-      firstBehavior.responseTemplate = 'clowncar';
+      editorConfig.group = editorConfig.group.behaviorVersions[0].buildUpdatedGroupFor(editorConfig.group, {
+        responseTemplate: ResponseTemplate.fromString('clowncar')
+      });
       let editor = createEditor(editorConfig);
       const template = editor.getBehaviorTemplate();
       expect(template && template.toString()).toEqual('clowncar');
     });
 
-    it('returns a default template when no template is defined', () => {
-      delete firstBehavior.responseTemplate;
+    it('returns an empty template when no template is defined', () => {
+      editorConfig.group = editorConfig.group.behaviorVersions[0].buildUpdatedGroupFor(editorConfig.group, {
+        responseTemplate: null
+      });
       let editor = createEditor(editorConfig);
       const template = editor.getBehaviorTemplate();
       expect(template && template.toString()).toEqual('');
    });
 
-    it('returns a default template when the template is blank', () => {
-      firstBehavior.responseTemplate = '';
-      let editor = createEditor(editorConfig);
-      const template = editor.getBehaviorTemplate();
-      expect(template && template.toString()).toEqual('');
-    });
-
     it('returns the template when it’s empty on an existing skill', () => {
-      firstBehavior.responseTemplate = '';
+      editorConfig.group = editorConfig.group.behaviorVersions[0].buildUpdatedGroupFor(editorConfig.group, {
+        responseTemplate: ResponseTemplate.fromString('')
+      });
       let editor = createEditor(editorConfig);
       const template = editor.getBehaviorTemplate();
       expect(template && template.toString()).toEqual('');
@@ -365,7 +374,11 @@ describe('BehaviorEditor', () => {
 
   describe('render', () => {
     it("renders the normal editor when isDataType is false", () => {
-      firstBehavior.config.isDataType = false;
+      editorConfig.group = editorConfig.group.behaviorVersions[0].buildUpdatedGroupFor(editorConfig.group, {
+        config: editorConfig.group.behaviorVersions[0].config.clone({
+          isDataType: false
+        })
+      });
       const editor = createEditor(editorConfig);
       const dataSpy = jest.spyOn(editor, 'renderDataTypeBehavior');
       const normalSpy = jest.spyOn(editor, 'renderNormalBehavior');
@@ -374,9 +387,12 @@ describe('BehaviorEditor', () => {
       expect(normalSpy).toBeCalled();
     });
     it("renders the data type editor when isDataType is true", () => {
-      const bv: BehaviorVersionJson = editorConfig.group.behaviorVersions[0];
-      bv.config.isDataType = true;
-      bv.config.dataTypeConfig = { fields: [], usesCode: true };
+      editorConfig.group = editorConfig.group.behaviorVersions[0].buildUpdatedGroupFor(editorConfig.group, {
+        config: editorConfig.group.behaviorVersions[0].config.clone({
+          isDataType: true,
+          dataTypeConfig: DataTypeConfig.fromJson({ fields: [], usesCode: true })
+        })
+      });
       const editor = createEditor(editorConfig);
       const dataSpy = jest.spyOn(editor, 'renderDataTypeBehavior');
       const normalSpy = jest.spyOn(editor, 'renderNormalBehavior');
@@ -396,31 +412,32 @@ describe('BehaviorEditor', () => {
   describe('isJustSaved', () => {
     const HALF_MINUTE = 30000;
     const TWO_MINUTES = 120000;
+
     it("false if recent save but isModified() is true", () => {
-      let config = Object.assign({}, editorConfig, {
-        group: Object.assign({}, editorConfig.group, { createdAt: Number(new Date()) - HALF_MINUTE })
+      editorConfig.group = editorConfig.group.clone({
+        createdAt: Number(new Date()) - HALF_MINUTE
       });
-      let editor = createEditor(config);
+      let editor = createEditor(editorConfig);
       editor.isModified = jest.fn(() => true);
       let justSaved = editor.isJustSaved();
       expect(justSaved).toEqual(false);
     });
 
     it("false if not a recent save", () => {
-      let config = Object.assign({}, editorConfig, {
-        group: Object.assign({}, editorConfig.group, { createdAt: Number(new Date()) - TWO_MINUTES })
+      editorConfig.group = editorConfig.group.clone({
+        createdAt: Number(new Date()) - TWO_MINUTES
       });
-      let editor = createEditor(config);
+      let editor = createEditor(editorConfig);
       editor.isModified = jest.fn(() => false);
       let justSaved = editor.isJustSaved();
       expect(justSaved).toEqual(false);
     });
 
     it("true if a recent save and isModified() is false", () => {
-      let config = Object.assign({}, editorConfig, {
-        group: Object.assign({}, editorConfig.group, { createdAt: Number(new Date()) - HALF_MINUTE })
+      editorConfig.group = editorConfig.group.clone({
+        createdAt: Number(new Date()) - HALF_MINUTE
       });
-      let editor = createEditor(config);
+      let editor = createEditor(editorConfig);
       editor.isModified = jest.fn(() => false);
       let justSaved = editor.isJustSaved();
       expect(justSaved).toEqual(true);
@@ -431,22 +448,21 @@ describe('BehaviorEditor', () => {
     it("returns the (unique by inputId) saved params", () => {
       const groupId = editorConfig.group.id;
       const inputId = "abcd12345";
-      const savedAnswerInput = {
+      const savedAnswerInput: Input = Input.fromJson({
         name: 'foo',
         question: '',
         paramType: editorConfig.builtinParamTypes[0],
         isSavedForTeam: false,
         isSavedForUser: true,
-        inputId: inputId,
-        groupId: groupId
-      };
-      const otherBehaviorsInGroup: Array<BehaviorVersionJson> = [
+        inputId: inputId
+      });
+      const otherBehaviorsInGroup: Array<BehaviorVersion> = [
           {
             teamId: "1",
             behaviorId: "2",
             functionBody: "",
             responseTemplate: "",
-            inputIds: [savedAnswerInput.inputId],
+            inputIds: [inputId],
             triggers: [],
             config: {
               isDataType: false,
@@ -460,7 +476,7 @@ describe('BehaviorEditor', () => {
             behaviorId: "3",
             functionBody: "",
             responseTemplate: "",
-            inputIds: [savedAnswerInput.inputId],
+            inputIds: [inputId],
             triggers: [],
             config: {
               isDataType: false,
@@ -469,18 +485,25 @@ describe('BehaviorEditor', () => {
             },
             groupId: groupId
           }
-        ].map(ea => BehaviorVersion.fromJson(ea));
-      let allVersions = editorConfig.group.behaviorVersions.concat(otherBehaviorsInGroup);
-      let newGroup = Object.assign({}, editorConfig.group, { actionInputs: [savedAnswerInput], behaviorVersions: allVersions });
-      let config = Object.assign({}, editorConfig, { group: newGroup });
-      let editor = createEditor(config);
+        ].map(BehaviorVersion.fromJson);
+      editorConfig.group = editorConfig.group.clone({
+        actionInputs: [savedAnswerInput],
+        behaviorVersions: editorConfig.group.behaviorVersions.concat(otherBehaviorsInGroup)
+      });
+      const editor = createEditor(editorConfig);
       expect(editor.getOtherSavedInputsInGroup().map(ea => ea.inputId)).toEqual([otherBehaviorsInGroup[0].inputIds[0]]);
     });
   });
 
   describe('setBehaviorConfigProps', () => {
     it("clones the existing behavior config with updated properties", () => {
-      editorConfig.group.behaviorVersions[0].config.responseTypeId = normalResponseType;
+      editorConfig.group = editorConfig.group.clone({
+        behaviorVersions: [editorConfig.group.behaviorVersions[0].clone({
+          config: editorConfig.group.behaviorVersions[0].config.clone({
+            responseTypeId: normalResponseType
+          })
+        })]
+      });
       let editor = createEditor(editorConfig);
       const config = editor.getBehaviorConfig();
       expect(config && config.responseTypeId).toBe(normalResponseType);


### PR DESCRIPTION
When I rewrote things into Typescript, I messed up preserving the order of inputs on behaviors (they are showing up in the essentially random order of the inputs at the skill level).

This fixes that, and adds a test for it. I discovered that our existing tests were a lot less strongly typed than I realized, so I fixed that.

I think we badly need to turn on --noImplicitAny. 😑 