### PR TITLE
Stop triggers from disappearing on the skill editor switcher panel

### DIFF
--- a/app/assets/stylesheets/boxes.less
+++ b/app/assets/stylesheets/boxes.less
@@ -91,7 +91,7 @@
 
 .box-chat {
   position: relative;
-  display: inline-block;
+  display: inline;
   box-sizing: border-box;
   border-radius: @border-radius-small @border-radius-small @border-radius-small 0;
   vertical-align: middle;


### PR DESCRIPTION
Change box-chat to inline instead of inline block, so that overflow: ellipsis doesn't hide content on Firefox

Resolves #2692 