### PR TITLE
Add support for using browser back/forward to navigate between editable components

### DIFF
--- a/app/assets/frontend/behavior_editor/index.tsx
+++ b/app/assets/frontend/behavior_editor/index.tsx
@@ -1152,7 +1152,7 @@ class BehaviorEditor extends React.Component<Props, State> {
       versionBrowserOpen: this.props.activePanelName === 'versionBrowser'
     }, () => {
       if (this.state.versionBrowserOpen) {
-        BrowserUtils.replaceQueryParam("showVersions", "true");
+        BrowserUtils.modifyQueryParam("showVersions", "true");
       } else {
         BrowserUtils.removeQueryParam("showVersions");
       }
@@ -1749,6 +1749,7 @@ class BehaviorEditor extends React.Component<Props, State> {
     window.addEventListener('resize', this.checkMobileLayout, false);
     window.addEventListener('scroll', debounce(this.updateBehaviorScrollPosition, 500), false);
     window.addEventListener('focus', () => this.checkForUpdatesLater(2000), false);
+    window.addEventListener('popstate', this.browserDidPopState, false);
     this.checkForUpdatesLater();
     this.loadNodeModuleVersions();
     this.loadTestResults();
@@ -1762,6 +1763,20 @@ class BehaviorEditor extends React.Component<Props, State> {
   componentDidUpdate(): void {
     this.renderNavItems();
     this.renderNavActions();
+  }
+
+  browserDidPopState(): void {
+    const urlSelectedId = BrowserUtils.getQueryParamValue("actionId");
+    const showVersions = BrowserUtils.getQueryParamValue("showVersions");
+    const currentSelectedId = this.getSelectedId();
+    if (urlSelectedId !== currentSelectedId) {
+      this.onSelect(null, urlSelectedId);
+    }
+    if (showVersions === "true" && this.props.activePanelName !== "versionBrowser") {
+      this.showVersions();
+    } else if (!showVersions && this.props.activePanelName === "versionBrowser") {
+      this.props.onClearActivePanel();
+    }
   }
 
   checkForUpdates(): void {
@@ -2275,7 +2290,7 @@ class BehaviorEditor extends React.Component<Props, State> {
     } : null);
     this.setState(newState, () => {
       if (optionalGroupId) {
-        BrowserUtils.replaceURL(jsRoutes.controllers.BehaviorEditorController.edit(optionalGroupId, optionalBehaviorId).url);
+        BrowserUtils.modifyURL(jsRoutes.controllers.BehaviorEditorController.edit(optionalGroupId, optionalBehaviorId).url);
       }
       window.scrollTo(window.scrollX, this.getEditorScrollPosition());
       this.setState({

--- a/app/assets/frontend/lib/browser_utils.ts
+++ b/app/assets/frontend/lib/browser_utils.ts
@@ -9,6 +9,12 @@ const BrowserUtils = {
       }
     },
 
+    getQueryParamValue: function(qpName: string): Option<string> {
+      const url = new URI();
+      const params = url.query(true) as { [q: string]: string | undefined };
+      return params[qpName] || null;
+    },
+
     hasQueryParam: function(qpName: string): boolean {
       var url = new URI();
       return url.hasQuery(qpName);
@@ -20,19 +26,29 @@ const BrowserUtils = {
     },
 
     removeQueryParam: function(qpName: string): void {
-      var url = new URI();
-      url.removeQuery(qpName);
-      this.replaceURL(url.href());
+      const existingValue = this.getQueryParamValue(qpName);
+      if (typeof existingValue === "string") {
+        const url = new URI();
+        url.removeQuery(qpName);
+        this.modifyURL(url.href());
+      }
     },
 
-    replaceQueryParam: function(qpName: string, value: string): void {
-      var url = new URI();
-      url.removeQuery(qpName).addQuery(qpName, value);
-      this.replaceURL(url.href());
+    modifyQueryParam: function(qpName: string, value: string): void {
+      const existingValue = this.getQueryParamValue(qpName);
+      if (existingValue !== value) {
+        const url = new URI();
+        url.removeQuery(qpName).addQuery(qpName, value);
+        this.modifyURL(url.href());
+      }
     },
 
     replaceURL: function(url: string): void {
       window.history.replaceState({}, "", url);
+    },
+
+    modifyURL: function(url: string): void {
+      window.history.pushState({}, "", url);
     },
 
     loadURL: function(url: string): void {

--- a/app/assets/frontend/settings/oauth_editor/index.tsx
+++ b/app/assets/frontend/settings/oauth_editor/index.tsx
@@ -126,7 +126,7 @@ class IntegrationEditor extends React.Component<Props, State> {
         if (this.applicationNameInput) {
           this.applicationNameInput.focus();
         }
-        BrowserUtils.replaceQueryParam('apiId', api.apiId);
+        BrowserUtils.modifyQueryParam('apiId', api.apiId);
       });
     }
 

--- a/test/assets/frontend/lib/browser_utils_spec.ts
+++ b/test/assets/frontend/lib/browser_utils_spec.ts
@@ -1,0 +1,80 @@
+import BrowserUtils from "../../../../app/assets/frontend/lib/browser_utils";
+
+let location: string;
+let history: Array<string>;
+
+function reset() {
+  location = 'http://start.start/';
+  history = [location];
+}
+
+window.history.replaceState = jest.fn((data, title, newUrl: string) => {
+  location = newUrl;
+});
+window.history.pushState = jest.fn((data, title, newUrl: string) => {
+  location = newUrl;
+  history.push(newUrl);
+});
+
+jest.mock('urijs', () => {
+  // Super dumb mock that only lets you add/remove/check "?foo=bar"
+  class URI {
+    query() {
+      return /\?foo=bar/.test(location) ? { foo: "bar" } : {};
+    }
+
+    hasQuery() {
+      return Boolean(this.query().foo)
+    }
+
+    removeQuery() {
+      location = location.replace(/\?foo=bar$/, "");
+      return this;
+    }
+
+    addQuery() {
+      location = location + '?foo=bar';
+      return this;
+    }
+
+    href() {
+      return location;
+    }
+  }
+  return URI;
+});
+
+describe("BrowserUtils", () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    reset();
+  });
+
+  describe("replaceURL", () => {
+    it('replaces the existing browser history state without adding to it', () => {
+      BrowserUtils.replaceURL("http://hahaha.com");
+      expect(window.history.replaceState).toHaveBeenCalled();
+      expect(window.history.pushState).not.toHaveBeenCalled();
+      expect(history).toHaveLength(1);
+    });
+  });
+
+  describe("modifyUrl", () => {
+    it('adds a new entry to the browser history state', () => {
+      BrowserUtils.modifyURL("http://hahaha.com");
+      expect(window.history.pushState).toHaveBeenCalled();
+      expect(window.history.replaceState).not.toHaveBeenCalled();
+      expect(history).toHaveLength(2);
+    });
+  });
+
+  describe("modifyQueryParam", () => {
+    it('modifies the URL only if a query parameter is not already set to that value', () => {
+      BrowserUtils.modifyQueryParam("foo", "bar");
+      BrowserUtils.modifyQueryParam("foo", "bar");
+      expect(window.history.pushState).toHaveBeenCalledTimes(1);
+      expect(history).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
- Doesn't work on new skills yet
- Would be better if it updated the title when switching so browser history is more useful
