### PR TITLE
Change slick threads & connections config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
   "com.mohiva" %% "play-silhouette-persistence" % "5.0.0",
   "com.mohiva" %% "play-silhouette-crypto-jca" % "5.0.0",
   "com.mohiva" %% "play-silhouette-testkit" % "5.0.0" % Test,
-  "com.typesafe.slick" %% "slick-hikaricp" % "3.2.1",
+  "com.typesafe.slick" %% "slick-hikaricp" % "3.2.3",
   "com.typesafe.play" %% "play-slick" % "3.0.3",
   "com.typesafe.play" %% "play-slick-evolutions" % "3.0.3",
   "ai.x" %% "play-json-extensions" % "0.10.0",

--- a/conf/db.conf
+++ b/conf/db.conf
@@ -4,9 +4,9 @@ slick {
       profile = "drivers.SlickPostgresDriver$"
       db {
         driver="org.postgresql.Driver"
-        numThreads=20
+        numThreads=10
         numThreads=${?SLICK_NUM_THREADS}
-        maxConnections=20
+        maxConnections=10
         maxConnections=${?SLICK_MAX_CONNECTIONS}
         queueSize=1000
         queueSize=${?SLICK_QUEUE_SIZE}


### PR DESCRIPTION
 It seems that Slick now recommends a different configuration for numbers of threads and connections
- updated to have them default to equal, and all changing them with env vars