### PR TITLE
Sort the scheduling page channels (and within each channel) by first recurrence

### DIFF
--- a/app/assets/frontend/lib/sort.ts
+++ b/app/assets/frontend/lib/sort.ts
@@ -12,6 +12,17 @@ const Sort = {
           return 0;
         }
       });
+    },
+
+    arrayAscending: function<T>(array: Array<T>, mapItemToProperty: (item: T) => number) {
+      const copy = array.slice();
+      return copy.sort((a, b) => {
+        return mapItemToProperty(a) - mapItemToProperty(b);
+      });
+    },
+
+    arrayDescending: function<T>(array: Array<T>, mapItemToProperty: (item: T) => number) {
+      return this.arrayAscending(array, mapItemToProperty).reverse();
     }
 };
 

--- a/app/assets/frontend/models/scheduled_action.tsx
+++ b/app/assets/frontend/models/scheduled_action.tsx
@@ -20,7 +20,7 @@ export interface ScheduledActionJson {
   secondRecurrence?: Option<Timestamp>,
   useDM: boolean,
   channel: string,
-  userId: Option<string>
+  userId?: Option<string>
 }
 
 export interface ScheduledActionInterface extends ScheduledActionJson {

--- a/app/assets/frontend/scheduling/index.tsx
+++ b/app/assets/frontend/scheduling/index.tsx
@@ -212,16 +212,14 @@ class Scheduling extends React.Component<Props, State> {
         group.actions.push(action);
         groupsByName[groupName] = group;
       });
-      const channelNames = Object.keys(groupsByName);
-      const sortedNames = Sort.arrayAlphabeticalBy(channelNames, (ea) => ea);
-      const sortedGroups: Array<ScheduleGroup> = [];
-      sortedNames.forEach((channelName) => {
-        const group = groupsByName[channelName];
-        if (group) {
-          sortedGroups.push(group);
-        }
+      const groupArray = Object.keys(groupsByName).map((channelName) => {
+        const group = groupsByName[channelName] as ScheduleGroup;
+        group.actions = Sort.arrayAscending(group.actions, (action) => action.firstRecurrence ? Number(action.firstRecurrence) : Infinity);
+        return group;
       });
-      return sortedGroups;
+      return Sort.arrayAscending(groupArray, (group) => {
+        return group.actions[0].firstRecurrence ? Number(group.actions[0].firstRecurrence) : Infinity
+      });
     }
 
     shouldShowChannel(channelId: string): boolean {

--- a/test/assets/frontend/lib/sort_spec.ts
+++ b/test/assets/frontend/lib/sort_spec.ts
@@ -25,4 +25,23 @@ describe('Sort', () => {
       expect(array.map(ea => ea.name)).toEqual(["Delta", "bravo", "charlie", "Alpha"]);
     });
   });
+
+  describe('arrayAscending', () => {
+    it('copies the vars and sorts them numerically by property in ascending order', () => {
+      const array = [{ num: 0 }, { num: 5 }, { num: -5 }];
+      const sorted = Sort.arrayAscending(array, (ea) => ea.num);
+      expect(sorted.map((ea) => ea.num)).toEqual([-5, 0, 5]);
+      expect(array.map((ea) => ea.num)).toEqual([0, 5, -5]);
+    });
+  });
+
+  describe('arrayDescending', () => {
+    it('copies the vars and sorts them numerically by property in descending order', () => {
+      const array = [{ num: 0 }, { num: 5 }, { num: -5 }];
+      const sorted = Sort.arrayDescending(array, (ea) => ea.num);
+      expect(sorted.map((ea) => ea.num)).toEqual([5, 0, -5]);
+      expect(array.map((ea) => ea.num)).toEqual([0, 5, -5]);
+    });
+  });
+
 });

--- a/test/assets/frontend/scheduling/scheduling_spec.tsx
+++ b/test/assets/frontend/scheduling/scheduling_spec.tsx
@@ -81,13 +81,13 @@ const emptyConfig: SchedulingProps = {
 };
 
 function newSchedule(props?: Partial<ScheduledActionInterface>) {
-  return new ScheduledAction(Object.assign({
+  return new ScheduledAction(Object.assign<ScheduledActionInterface, Partial<ScheduledActionInterface> | undefined>({
     id: ID.next(),
     scheduleType: "message",
     behaviorId: ID.next(),
     behaviorGroupId: ID.next(),
     trigger: ":tada:",
-    arguments: {},
+    arguments: [],
     recurrence: new Recurrence({
       timeZone: defaultTimeZone,
       timeZoneName: defaultTimeZoneName
@@ -100,9 +100,9 @@ function newSchedule(props?: Partial<ScheduledActionInterface>) {
 }
 
 function newChannel(props?: Partial<ScheduleChannelInterface>) {
-  return new ScheduleChannel(Object.assign({
+  return new ScheduleChannel(Object.assign<ScheduleChannelInterface, Partial<ScheduleChannelInterface> | undefined>({
     id: defaultChannelId,
-    name: "test",
+    name: "channel",
     context: "Slack",
     isBotMember: true,
     isSelfDm: false,
@@ -151,10 +151,13 @@ describe('Scheduling', () => {
     });
 
     it('renders with some scheduled items', () => {
-      const wrapper = createIndexWrapper(Object.assign({}, emptyConfig, {
+      const config = Object.assign<{}, SchedulingProps, Partial<SchedulingProps>>({}, emptyConfig, {
         scheduledActions: [newSchedule(), newSchedule()],
-        channelList: [newChannel()]
-      }));
+        orgChannels: emptyConfig.orgChannels.clone({
+          teamChannels: [TeamChannels.fromJson({ teamName: "Test team", channelList: [newChannel()] })]
+        })
+      });
+      const wrapper = createIndexWrapper(config);
       const page = wrapper.page;
       const noScheduleSpy = jest.spyOn(page, 'renderNoSchedules');
       const errorMessageSpy = jest.spyOn(page, 'renderErrorMessage');
@@ -176,7 +179,9 @@ describe('Scheduling', () => {
       }), newSchedule()];
       const wrapper = createIndexWrapper(Object.assign({}, emptyConfig, {
         scheduledActions: schedules,
-        channelList: channels,
+        orgChannels: emptyConfig.orgChannels.clone({
+          teamChannels: [TeamChannels.fromJson({ teamName: "Test team", channelList: channels })]
+        }),
         selectedScheduleId: null
       }));
       const page = wrapper.page;
@@ -209,7 +214,7 @@ describe('Scheduling', () => {
 
   describe('componentWillReceiveProps', () => {
     it('sets state to justSaved if current props isSaving is true, and new props isSaving is false', () => {
-      const config = Object.assign({}, emptyConfig, {
+      const config = Object.assign<{}, SchedulingProps, Partial<SchedulingProps>>({}, emptyConfig, {
         isSaving: true
       });
       const wrapper = createIndexWrapper(config);
@@ -227,7 +232,7 @@ describe('Scheduling', () => {
     });
 
     it('sets state to justDeleted if current props isDeleting is true, and new props isDeleting is false', () => {
-      const config = Object.assign({}, emptyConfig, {
+      const config = Object.assign<{}, SchedulingProps, Partial<SchedulingProps>>({}, emptyConfig, {
         isDeleting: true
       });
       const wrapper = createIndexWrapper(config);
@@ -255,7 +260,9 @@ describe('Scheduling', () => {
       })];
       const config = Object.assign({}, emptyConfig, {
         scheduledActions: schedules,
-        channelList: channels,
+        orgChannels: emptyConfig.orgChannels.clone({
+          teamChannels: [TeamChannels.fromJson({ teamName: "Test team", channelList: channels })]
+        }),
         selectedScheduleId: schedules[0].id,
         isDeleting: true
       });
@@ -285,9 +292,11 @@ describe('Scheduling', () => {
       const schedules = [newSchedule({
         channel: channels[0].id
       })];
-      const config = Object.assign({}, emptyConfig, {
+      const config = Object.assign<{}, SchedulingProps, Partial<SchedulingProps>>({}, emptyConfig, {
         scheduledActions: schedules,
-        channelList: channels,
+        orgChannels: emptyConfig.orgChannels.clone({
+          teamChannels: [TeamChannels.fromJson({ teamName: "Test team", channelList: channels })]
+        }),
         selectedScheduleId: schedules[0].id,
         isDeleting: true
       });
@@ -311,4 +320,26 @@ describe('Scheduling', () => {
       });
     });
   });
+
+  describe('getScheduleByChannel', () => {
+    it('returns scheduled actions grouped by channel, with channels and actions in a channel both sorted ascending by first recurrence', () => {
+      const channel1 = newChannel({ name: "channel1", id: "channel1" });
+      const channel2 = newChannel({ name: "channel2", id: "channel2" });
+      const action1 = newSchedule({ firstRecurrence: new Date("2020-01-01T00:00:00.000Z"), channel: "channel1" });
+      const action2 = newSchedule({ firstRecurrence: new Date("2018-01-01T00:00:00.000Z"), channel: "channel2" });
+      const action3 = newSchedule({ firstRecurrence: new Date("2019-01-01T00:00:00.000Z"), channel: "channel1" });
+      const action4 = newSchedule({ firstRecurrence: new Date("2020-01-01T00:00:00.000Z"), channel: "channel2" });
+      const wrapper = createIndexWrapper(Object.assign<{}, SchedulingProps, Partial<SchedulingProps>>({}, emptyConfig, {
+        scheduledActions: [action1, action2, action3, action4],
+        orgChannels: emptyConfig.orgChannels.clone({
+          teamChannels: [TeamChannels.fromJson({ teamName: "Test team", channelList: [channel1, channel2] })]
+        }),
+      }));
+      const page = wrapper.page;
+      const grouped = page.getScheduleByChannel();
+      expect(grouped.map((ea) => ea.channelId)).toEqual(["channel2", "channel1"]);
+      expect(grouped[0].actions).toEqual([action2, action4]);
+      expect(grouped[1].actions).toEqual([action3, action1]);
+    });
+  })
 });


### PR DESCRIPTION
Updated specs with some fun new strict types for Object.assign which turns out to not be very smart in the version of Typescript we have.