### PR TITLE
Strip a bunch of junk from MS Teams HTML text so triggers have a better chance of working

### DIFF
--- a/app/utils/MSTeamsUtils.scala
+++ b/app/utils/MSTeamsUtils.scala
@@ -1,0 +1,10 @@
+package utils
+
+import scala.util.matching.Regex
+
+object MSTeamsUtils {
+
+  val emojiRegex = new Regex("""<img.+?alt=\"(.+?)\".+?>""", "altText")
+  val nbspRegex = s"""&nbsp;"""
+
+}


### PR DESCRIPTION
- currently we need to use HTML messages because the plain text ones leave out stuff like emoji