### PR TITLE
Cache changes cleanup

### DIFF
--- a/app/controllers/SlackController.scala
+++ b/app/controllers/SlackController.scala
@@ -544,8 +544,6 @@ class SlackController @Inject() (
       value.map { v =>
         cacheService.getSlackActionValue(v).map { maybeV =>
           maybeV.orElse(value)
-        }.recover {
-          case e: IllegalArgumentException => value
         }
       }.getOrElse(Future.successful(value))
     }

--- a/app/services/caching/CacheService.scala
+++ b/app/services/caching/CacheService.scala
@@ -21,6 +21,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
+case class InvalidCacheValueType(message: String) extends Exception(message)
+
 trait CacheService {
 
   def toJsonString[T](o: T)(implicit tjs: Writes[T]): String = {
@@ -32,6 +34,10 @@ trait CacheService {
       case JsSuccess(value, _) => Some(value)
       case JsError(_) => None
     }
+  }
+
+  def forceValidKey(key: String): String = {
+    key.replaceAll("""\s""", "_").slice(0, 249)
   }
 
   def set[T: ClassTag](key: String, value: T, expiration: Duration = Duration.Inf): Future[Unit]


### PR DESCRIPTION
Clean up some caching changes: use a non-generic exception when rejecting JsValues, and add some restrictions on slack action value keys so that we don't accidentally return the wrong cache value

The way I read this, the old code could theoretically (though not in practice I think) return unexpected cache hits because memcached would only read the key up to the first whitespace, and we were passing through the slack action value as a key as-is.