### PR TITLE
Since the api and scheduled cases might also want message-related info like channel and thread ID,  include the message property in those cases too

### DIFF
--- a/app/models/behaviors/events/Event.scala
+++ b/app/models/behaviors/events/Event.scala
@@ -106,7 +106,7 @@ trait Event {
                         maybeConversation: Option[Conversation],
                         services: DefaultServices
                       )(implicit actorSystem: ActorSystem, ec: ExecutionContext): DBIO[Option[MessageObject]] = {
-    DBIO.successful(None)
+    MessageObject.buildForAction(this, maybeConversation, services).map(Some(_))
   }
 
   def messageUserDataListAction(services: DefaultServices)(implicit ec: ExecutionContext): DBIO[Set[UserData]]

--- a/app/models/behaviors/events/MessageEvent.scala
+++ b/app/models/behaviors/events/MessageEvent.scala
@@ -1,13 +1,9 @@
 package models.behaviors.events
 
-import akka.actor.ActorSystem
 import models.behaviors.BehaviorResponse
 import models.behaviors.behavior.Behavior
-import models.behaviors.conversations.conversation.Conversation
-import models.behaviors.ellipsisobject.MessageObject
 import models.team.Team
 import services.DefaultServices
-import slick.dbio.DBIO
 import utils.FileReference
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -22,13 +18,6 @@ trait MessageEvent extends Event {
 
   def maybeNewFileId(services: DefaultServices): Option[String] = maybeFile.map { file =>
     services.fileMap.save(file)
-  }
-
-  override def maybeMessageInfoAction(
-                              maybeConversation: Option[Conversation],
-                              services: DefaultServices
-                            )(implicit actorSystem: ActorSystem, ec: ExecutionContext): DBIO[Option[MessageObject]] = {
-    MessageObject.buildForAction(this, maybeConversation, services).map(Some(_))
   }
 
   def allBehaviorResponsesFor(

--- a/app/models/behaviors/events/slack/SlackReactionAddedEvent.scala
+++ b/app/models/behaviors/events/slack/SlackReactionAddedEvent.scala
@@ -4,8 +4,6 @@ import akka.actor.ActorSystem
 import json.UserData
 import models.behaviors.BehaviorResponse
 import models.behaviors.behavior.Behavior
-import models.behaviors.conversations.conversation.Conversation
-import models.behaviors.ellipsisobject.MessageObject
 import models.behaviors.events.{Event, EventType, SlackEventContext}
 import models.behaviors.scheduling.Scheduled
 import models.team.Team
@@ -32,13 +30,6 @@ case class SlackReactionAddedEvent(
   lazy val invocationLogText: String = relevantMessageText
 
   val maybeOriginalEventType: Option[EventType] = None
-
-  override def maybeMessageInfoAction(
-                                       maybeConversation: Option[Conversation],
-                                       services: DefaultServices
-                                     )(implicit actorSystem: ActorSystem, ec: ExecutionContext): DBIO[Option[MessageObject]] = {
-    MessageObject.buildForAction(this, maybeConversation, services).map(Some(_))
-  }
 
   override def maybePermalinkFor(services: DefaultServices)(implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[Option[String]] = {
     (for {


### PR DESCRIPTION
- one could argue that it shouldn't be called message in this case, or that these properties should be moved up to the `event` or `ellipsis` level, but this change is at least non-breaking for now