### PR TITLE
Prep work to support validating a set of scheduled messages at the same time

### DIFF
--- a/app/assets/frontend/types/jsRoutes.d.ts
+++ b/app/assets/frontend/types/jsRoutes.d.ts
@@ -71,7 +71,7 @@ declare var jsRoutes: {
       index: (selectedId: Option<string>, isNewSchedule: Option<boolean>, filterChannelId: Option<string>, teamId: Option<string>, forceAdmin: Option<boolean>) => JsRoute,
       save: () => JsRoute,
       validateRecurrence: () => JsRoute,
-      validateTrigger: () => JsRoute
+      validateTriggers: () => JsRoute
     },
     SocialAuthController: {
       authenticateGithub: (redirectUrl?: Option<string>, teamId?: Option<string>, channelId?: Option<string>) => JsRoute

--- a/app/json/Formatting.scala
+++ b/app/json/Formatting.scala
@@ -140,7 +140,7 @@ object Formatting {
   lazy implicit val scheduleChannelDataWrites = Json.writes[ScheduleChannelData]
 
   lazy implicit val recurrenceValidationDataFormat = Json.format[RecurrenceValidationData]
-  lazy implicit val triggerValidationDataFormat = Json.format[TriggerValidationData]
+  lazy implicit val triggerValidationDataFormat = Json.format[ValidateTriggersRequestData]
   lazy implicit val validTriggerDataFormat = Json.format[ValidTriggerData]
 
   lazy implicit val teamChannelsDataFormat = Json.format[TeamChannelsData]

--- a/app/json/TriggerValidationData.scala
+++ b/app/json/TriggerValidationData.scala
@@ -1,3 +1,0 @@
-package json
-
-case class TriggerValidationData(text: String, teamId: String)

--- a/app/json/ValidTriggerData.scala
+++ b/app/json/ValidTriggerData.scala
@@ -1,3 +1,3 @@
 package json
 
-case class ValidTriggerData(trigger: BehaviorTriggerData, behaviorId: String)
+case class ValidTriggerData(text: String, matchingTriggers: Seq[BehaviorTriggerData], matchingBehaviorIds: Seq[String])

--- a/app/json/ValidateTriggersRequestData.scala
+++ b/app/json/ValidateTriggersRequestData.scala
@@ -1,0 +1,3 @@
+package json
+
+case class ValidateTriggersRequestData(triggerMessages: Seq[String], teamId: String)

--- a/app/views/shared/jsRoutes.scala.js
+++ b/app/views/shared/jsRoutes.scala.js
@@ -48,7 +48,7 @@
   routes.javascript.ScheduledActionsController.delete,
   routes.javascript.ScheduledActionsController.save,
   routes.javascript.ScheduledActionsController.validateRecurrence,
-  routes.javascript.ScheduledActionsController.validateTrigger,
+  routes.javascript.ScheduledActionsController.validateTriggers,
   routes.javascript.SocialAuthController.authenticateGithub,
   routes.javascript.SupportController.sendRequest,
 

--- a/conf/routes
+++ b/conf/routes
@@ -83,7 +83,7 @@ GET         /scheduling                               @controllers.ScheduledActi
 POST        /save_schedule                            @controllers.ScheduledActionsController.save
 POST        /delete_schedule                          @controllers.ScheduledActionsController.delete
 POST        /validate_recurrence                      @controllers.ScheduledActionsController.validateRecurrence
-POST        /scheduling/validate_trigger              @controllers.ScheduledActionsController.validateTrigger
+POST        /scheduling/validate_triggers             @controllers.ScheduledActionsController.validateTriggers
 
 GET         /authenticate/slack                       @controllers.SocialAuthController.authenticateSlack(redirect: Option[String] ?= None, team: Option[String] ?= None, channel: Option[String] ?= None)
 GET         /install/slack                            @controllers.SocialAuthController.installForSlack(redirect: Option[String] ?= None, team: Option[String] ?= None, channel: Option[String] ?= None)


### PR DESCRIPTION
Change the trigger validation to accept multiple trigger messages and return a result for each one that lists the associated triggers and behavior IDs