### PR TITLE
If no `value` prop is passed to the checkbox component, send "on" as the normal default

### DIFF
--- a/app/assets/frontend/form/checkbox.tsx
+++ b/app/assets/frontend/form/checkbox.tsx
@@ -68,7 +68,7 @@ class Checkbox extends React.PureComponent<Props> {
           onChange={this.onChange}
           onKeyPress={this.handleEnterKey}
           name={this.props.name}
-          value={this.props.value}
+          value={this.props.value || "on"}
           disabled={this.props.disabledWhen}
         />
         <span>{this.props.label}</span>


### PR DESCRIPTION
- previous behavior was to send nothing
- one practical consequence was that our "isShared" toggle on api integrations was never getting set to true from the form