### PR TITLE
Move from a column on oauth applications to a separate table for capturing token sharing

### DIFF
--- a/app/models/accounts/OAuthApplication.scala
+++ b/app/models/accounts/OAuthApplication.scala
@@ -13,6 +13,5 @@ trait OAuthApplication {
   val maybeScope: Option[String]
   val teamId: String
   val isShared: Boolean
-  val maybeSharedTokenUserId: Option[String]
   def maybeTokenSharingAuthUrl(implicit request: SecuredRequest[EllipsisEnv, AnyContent]): Option[String]
 }

--- a/app/models/accounts/linkedoauth1token/LinkedOAuth1TokenServiceImpl.scala
+++ b/app/models/accounts/linkedoauth1token/LinkedOAuth1TokenServiceImpl.scala
@@ -51,17 +51,18 @@ class LinkedOAuth1TokenServiceImpl @Inject() (
     )
   }
 
-  def uncompiledAllSharedForTeamIdQuery(teamId: Rep[String]) = {
+  def uncompiledFindForQuery(userId: Rep[String], applicationId: Rep[String]) = {
     allWithApplication.
-      filter(_._2._1.maybeSharedTokenUserId.isDefined).
-      filter { case(_, (app, _)) => app.teamId === teamId || app.isShared }
+      filter { case(_, (app, _)) => app.id === applicationId }.
+      filter { case(link, _) => link.userId === userId }
   }
-  val allSharedForTeamIdQuery = Compiled(uncompiledAllSharedForTeamIdQuery _)
+  val findForQuery = Compiled(uncompiledFindForQuery _)
 
   def sharedForUserAction(user: User, ws: WSClient): DBIO[Seq[LinkedOAuth1Token]] = {
-    allSharedForTeamIdQuery(user.teamId).result.map { r =>
-      r.map(tuple2Token)
-    }
+    for {
+      shares <- dataService.oauth1TokenShares.allForAction(user.teamId)
+      links <- DBIO.sequence(shares.map(ea => findForQuery(ea.userId, ea.oauth1ApplicationId).result))
+    } yield links.flatten.map(tuple2Token)
   }
 
   def uncompiledAllForUserIdQuery(userId: Rep[String]) = {

--- a/app/models/accounts/oauth1application/OAuth1Application.scala
+++ b/app/models/accounts/oauth1application/OAuth1Application.scala
@@ -15,8 +15,7 @@ case class OAuth1Application(
                               consumerSecret: String,
                               maybeScope: Option[String],
                               teamId: String,
-                              isShared: Boolean,
-                              maybeSharedTokenUserId: Option[String]
+                              isShared: Boolean
                             ) extends OAuthApplication {
 
   val key: String = consumerKey
@@ -34,7 +33,6 @@ case class OAuth1Application(
     consumerSecret,
     maybeScope,
     teamId,
-    isShared,
-    maybeSharedTokenUserId
+    isShared
   )
 }

--- a/app/models/accounts/oauth1application/OAuth1ApplicationQueries.scala
+++ b/app/models/accounts/oauth1application/OAuth1ApplicationQueries.scala
@@ -12,7 +12,7 @@ object OAuth1ApplicationQueries {
 
   def tuple2Application(tuple: TupleType): OAuth1Application = {
     val raw = tuple._1
-    OAuth1Application(raw.id, raw.name, tuple._2, raw.consumerKey, raw.consumerSecret, raw.maybeScope, raw.teamId, raw.isShared, raw.maybeSharedTokenUserId)
+    OAuth1Application(raw.id, raw.name, tuple._2, raw.consumerKey, raw.consumerSecret, raw.maybeScope, raw.teamId, raw.isShared)
   }
 
   def uncompiledFindQuery(id: Rep[String]) = {

--- a/app/models/accounts/oauth1application/OAuth1ApplicationServiceImpl.scala
+++ b/app/models/accounts/oauth1application/OAuth1ApplicationServiceImpl.scala
@@ -16,8 +16,7 @@ case class RawOAuth1Application(
                                  consumerSecret: String,
                                  maybeScope: Option[String],
                                  teamId: String,
-                                 isShared: Boolean,
-                                 maybeSharedTokenUserId: Option[String]
+                                 isShared: Boolean
                                )
 
 class OAuth1ApplicationsTable(tag: Tag) extends Table[RawOAuth1Application](tag, "oauth1_applications") {
@@ -29,9 +28,8 @@ class OAuth1ApplicationsTable(tag: Tag) extends Table[RawOAuth1Application](tag,
   def maybeScope = column[Option[String]]("scope")
   def teamId = column[String]("team_id")
   def isShared = column[Boolean]("is_shared")
-  def maybeSharedTokenUserId = column[Option[String]]("shared_token_user_id")
 
-  def * = (id, name, apiId, consumerKey, consumerSecret, maybeScope, teamId, isShared, maybeSharedTokenUserId) <>
+  def * = (id, name, apiId, consumerKey, consumerSecret, maybeScope, teamId, isShared) <>
     ((RawOAuth1Application.apply _).tupled, RawOAuth1Application.unapply _)
 
 }

--- a/app/models/accounts/oauth1tokenshare/OAuth1TokenShare.scala
+++ b/app/models/accounts/oauth1tokenshare/OAuth1TokenShare.scala
@@ -1,0 +1,7 @@
+package models.accounts.oauth1tokenshare
+
+case class OAuth1TokenShare(
+                            oauth1ApplicationId: String,
+                            userId: String,
+                            teamId: String
+                            )

--- a/app/models/accounts/oauth1tokenshare/OAuth1TokenShareService.scala
+++ b/app/models/accounts/oauth1tokenshare/OAuth1TokenShareService.scala
@@ -1,0 +1,18 @@
+package models.accounts.oauth1tokenshare
+
+import models.accounts.oauth1application.OAuth1Application
+import models.accounts.user.User
+import models.team.Team
+import slick.dbio.DBIO
+
+import scala.concurrent.Future
+
+trait OAuth1TokenShareService {
+
+  def allForAction(teamId: String): DBIO[Seq[OAuth1TokenShare]]
+
+  def ensureFor(user: User, application: OAuth1Application): Future[OAuth1TokenShare]
+
+  def findFor(team: Team, application: OAuth1Application): Future[Option[OAuth1TokenShare]]
+
+}

--- a/app/models/accounts/oauth1tokenshare/OAuth1TokenShareServiceImpl.scala
+++ b/app/models/accounts/oauth1tokenshare/OAuth1TokenShareServiceImpl.scala
@@ -1,0 +1,59 @@
+package models.accounts.oauth1tokenshare
+
+import drivers.SlickPostgresDriver.api._
+import javax.inject.{Inject, Provider}
+import models.accounts.oauth1application.OAuth1Application
+import models.accounts.user.User
+import models.team.Team
+import services.DataService
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class OAuth1TokenSharesTable(tag: Tag) extends Table[OAuth1TokenShare](tag, "oauth1_token_shares") {
+  def applicationId = column[String]("application_id")
+  def userId = column[String]("user_id")
+  def teamId = column[String]("team_id")
+
+  def * = (applicationId, userId, teamId) <>
+    ((OAuth1TokenShare.apply _).tupled, OAuth1TokenShare.unapply _)
+
+}
+
+class OAuth1TokenShareServiceImpl @Inject() (
+                                               dataServiceProvider: Provider[DataService],
+                                               implicit val ec: ExecutionContext
+                                             ) extends OAuth1TokenShareService {
+
+  def dataService = dataServiceProvider.get
+
+  val all = TableQuery[OAuth1TokenSharesTable]
+
+  def uncompiledFindForQuery(teamId: Rep[String], applicationId: Rep[String]) = {
+    all.filter(_.teamId === teamId).filter(_.applicationId === applicationId)
+  }
+  val findForQuery = Compiled(uncompiledFindForQuery _)
+
+  def uncompiledAllForTeamIdQuery(teamId: Rep[String]) = {
+    all.filter(_.teamId === teamId)
+  }
+  val allForTeamIdQuery = Compiled(uncompiledAllForTeamIdQuery _)
+
+  def allForAction(teamId: String): DBIO[Seq[OAuth1TokenShare]] = {
+    allForTeamIdQuery(teamId).result
+  }
+
+  def ensureFor(user: User, application: OAuth1Application): Future[OAuth1TokenShare] = {
+    val newInstance = OAuth1TokenShare(application.id, user.id, user.teamId)
+    val action = (for {
+      _ <- findForQuery(user.teamId, application.id).delete
+      _ <- all += newInstance
+    } yield newInstance).transactionally
+    dataService.run(action)
+  }
+
+  def findFor(team: Team, application: OAuth1Application): Future[Option[OAuth1TokenShare]] = {
+    val action = findForQuery(team.id, application.id).result.map(_.headOption)
+    dataService.run(action)
+  }
+
+}

--- a/app/models/accounts/oauth2application/OAuth2Application.scala
+++ b/app/models/accounts/oauth2application/OAuth2Application.scala
@@ -20,8 +20,7 @@ case class OAuth2Application(
                               clientSecret: String,
                               maybeScope: Option[String],
                               teamId: String,
-                              isShared: Boolean,
-                              maybeSharedTokenUserId: Option[String]
+                              isShared: Boolean
                             ) extends OAuthApplication {
 
   val key: String = clientId
@@ -100,7 +99,6 @@ case class OAuth2Application(
     clientSecret,
     maybeScope,
     teamId,
-    isShared,
-    maybeSharedTokenUserId
+    isShared
   )
 }

--- a/app/models/accounts/oauth2application/OAuth2ApplicationQueries.scala
+++ b/app/models/accounts/oauth2application/OAuth2ApplicationQueries.scala
@@ -12,7 +12,7 @@ object OAuth2ApplicationQueries {
 
   def tuple2Application(tuple: TupleType): OAuth2Application = {
     val raw = tuple._1
-    OAuth2Application(raw.id, raw.name, tuple._2, raw.clientId, raw.clientSecret, raw.maybeScope, raw.teamId, raw.isShared, raw.maybeSharedTokenUserId)
+    OAuth2Application(raw.id, raw.name, tuple._2, raw.clientId, raw.clientSecret, raw.maybeScope, raw.teamId, raw.isShared)
   }
 
   def uncompiledFindQuery(id: Rep[String]) = {

--- a/app/models/accounts/oauth2application/OAuth2ApplicationServiceImpl.scala
+++ b/app/models/accounts/oauth2application/OAuth2ApplicationServiceImpl.scala
@@ -16,8 +16,7 @@ case class RawOAuth2Application(
                                  clientSecret: String,
                                  maybeScope: Option[String],
                                  teamId: String,
-                                 isShared: Boolean,
-                                 maybeSharedTokenUserId: Option[String]
+                                 isShared: Boolean
                                )
 
 class OAuth2ApplicationsTable(tag: Tag) extends Table[RawOAuth2Application](tag, "oauth2_applications") {
@@ -29,9 +28,8 @@ class OAuth2ApplicationsTable(tag: Tag) extends Table[RawOAuth2Application](tag,
   def maybeScope = column[Option[String]]("scope")
   def teamId = column[String]("team_id")
   def isShared = column[Boolean]("is_shared")
-  def maybeSharedTokenUserId = column[Option[String]]("shared_token_user_id")
 
-  def * = (id, name, apiId, clientId, clientSecret, maybeScope, teamId, isShared, maybeSharedTokenUserId) <>
+  def * = (id, name, apiId, clientId, clientSecret, maybeScope, teamId, isShared) <>
     ((RawOAuth2Application.apply _).tupled, RawOAuth2Application.unapply _)
 
 }

--- a/app/models/accounts/oauth2tokenshare/OAuth2TokenShare.scala
+++ b/app/models/accounts/oauth2tokenshare/OAuth2TokenShare.scala
@@ -1,0 +1,7 @@
+package models.accounts.oauth2tokenshare
+
+case class OAuth2TokenShare(
+                             oauth2ApplicationId: String,
+                             userId: String,
+                             teamId: String
+                           )

--- a/app/models/accounts/oauth2tokenshare/OAuth2TokenShareService.scala
+++ b/app/models/accounts/oauth2tokenshare/OAuth2TokenShareService.scala
@@ -1,0 +1,19 @@
+package models.accounts.oauth2tokenshare
+
+import models.accounts.oauth2application.OAuth2Application
+import models.accounts.user.User
+import models.team.Team
+import slick.dbio.DBIO
+
+import scala.concurrent.Future
+
+trait OAuth2TokenShareService {
+
+  def allForAction(teamId: String): DBIO[Seq[OAuth2TokenShare]]
+
+  def ensureFor(user: User, application: OAuth2Application): Future[OAuth2TokenShare]
+
+  def findFor(team: Team, application: OAuth2Application): Future[Option[OAuth2TokenShare]]
+
+
+}

--- a/app/models/accounts/oauth2tokenshare/OAuth2TokenShareServiceImpl.scala
+++ b/app/models/accounts/oauth2tokenshare/OAuth2TokenShareServiceImpl.scala
@@ -1,0 +1,59 @@
+package models.accounts.oauth2tokenshare
+
+import drivers.SlickPostgresDriver.api._
+import javax.inject.{Inject, Provider}
+import models.accounts.oauth2application.OAuth2Application
+import models.accounts.user.User
+import models.team.Team
+import services.DataService
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class OAuth2TokenSharesTable(tag: Tag) extends Table[OAuth2TokenShare](tag, "oauth2_token_shares") {
+  def applicationId = column[String]("application_id")
+  def userId = column[String]("user_id")
+  def teamId = column[String]("team_id")
+
+  def * = (applicationId, userId, teamId) <>
+    ((OAuth2TokenShare.apply _).tupled, OAuth2TokenShare.unapply _)
+
+}
+
+class OAuth2TokenShareServiceImpl @Inject() (
+                                              dataServiceProvider: Provider[DataService],
+                                              implicit val ec: ExecutionContext
+                                            ) extends OAuth2TokenShareService {
+
+  def dataService = dataServiceProvider.get
+
+  val all = TableQuery[OAuth2TokenSharesTable]
+
+  def uncompiledFindForQuery(teamId: Rep[String], applicationId: Rep[String]) = {
+    all.filter(_.teamId === teamId).filter(_.applicationId === applicationId)
+  }
+  val findForQuery = Compiled(uncompiledFindForQuery _)
+
+  def uncompiledAllForTeamIdQuery(teamId: Rep[String]) = {
+    all.filter(_.teamId === teamId)
+  }
+  val allForTeamIdQuery = Compiled(uncompiledAllForTeamIdQuery _)
+
+  def allForAction(teamId: String): DBIO[Seq[OAuth2TokenShare]] = {
+    allForTeamIdQuery(teamId).result
+  }
+
+  def ensureFor(user: User, application: OAuth2Application): Future[OAuth2TokenShare] = {
+    val newInstance = OAuth2TokenShare(application.id, user.id, user.teamId)
+    val action = (for {
+      _ <- findForQuery(user.teamId, application.id).delete
+      _ <- all += newInstance
+    } yield newInstance).transactionally
+    dataService.run(action)
+  }
+
+  def findFor(team: Team, application: OAuth2Application): Future[Option[OAuth2TokenShare]] = {
+    val action = findForQuery(team.id, application.id).result.map(_.headOption)
+    dataService.run(action)
+  }
+
+}

--- a/app/modules/ServiceModule.scala
+++ b/app/modules/ServiceModule.scala
@@ -12,9 +12,11 @@ import models.accounts.ms_teams.botprofile.{MSTeamsBotProfileService, MSTeamsBot
 import models.accounts.oauth1api.{OAuth1ApiService, OAuth1ApiServiceImpl}
 import models.accounts.oauth1application.{OAuth1ApplicationService, OAuth1ApplicationServiceImpl}
 import models.accounts.oauth1token.{OAuth1TokenService, OAuth1TokenServiceImpl}
+import models.accounts.oauth1tokenshare.{OAuth1TokenShareService, OAuth1TokenShareServiceImpl}
 import models.accounts.oauth2api.{OAuth2ApiService, OAuth2ApiServiceImpl}
 import models.accounts.oauth2application.{OAuth2ApplicationService, OAuth2ApplicationServiceImpl}
 import models.accounts.oauth2token.{OAuth2TokenService, OAuth2TokenServiceImpl}
+import models.accounts.oauth2tokenshare.{OAuth2TokenShareService, OAuth2TokenShareServiceImpl}
 import models.accounts.registration.{RegistrationService, RegistrationServiceImpl}
 import models.accounts.simpletokenapi.{SimpleTokenApiService, SimpleTokenApiServiceImpl}
 import models.accounts.slack.botprofile.{SlackBotProfileService, SlackBotProfileServiceImpl}
@@ -91,6 +93,8 @@ class ServiceModule extends AbstractModule with ScalaModule {
     bind[LinkedOAuth1TokenService].to[LinkedOAuth1TokenServiceImpl]
     bind[LinkedOAuth2TokenService].to[LinkedOAuth2TokenServiceImpl]
     bind[LinkedSimpleTokenService].to[LinkedSimpleTokenServiceImpl]
+    bind[OAuth1TokenShareService].to[OAuth1TokenShareServiceImpl]
+    bind[OAuth2TokenShareService].to[OAuth2TokenShareServiceImpl]
     bind[OAuth1ApiService].to[OAuth1ApiServiceImpl]
     bind[OAuth1ApplicationService].to[OAuth1ApplicationServiceImpl]
     bind[OAuth2ApiService].to[OAuth2ApiServiceImpl]

--- a/app/services/DataService.scala
+++ b/app/services/DataService.scala
@@ -10,9 +10,11 @@ import models.accounts.ms_teams.botprofile.MSTeamsBotProfileService
 import models.accounts.oauth1api.OAuth1ApiService
 import models.accounts.oauth1application.OAuth1ApplicationService
 import models.accounts.oauth1token.OAuth1TokenService
+import models.accounts.oauth1tokenshare.OAuth1TokenShareService
 import models.accounts.oauth2api.OAuth2ApiService
 import models.accounts.oauth2application.OAuth2ApplicationService
 import models.accounts.oauth2token.OAuth2TokenService
+import models.accounts.oauth2tokenshare.OAuth2TokenShareService
 import models.accounts.simpletokenapi.SimpleTokenApiService
 import models.accounts.slack.botprofile.SlackBotProfileService
 import models.accounts.slack.slackmemberstatus.SlackMemberStatusService
@@ -78,6 +80,8 @@ trait DataService {
   val linkedOAuth1Tokens: LinkedOAuth1TokenService
   val linkedOAuth2Tokens: LinkedOAuth2TokenService
   val linkedSimpleTokens: LinkedSimpleTokenService
+  val oauth1TokenShares: OAuth1TokenShareService
+  val oauth2TokenShares: OAuth2TokenShareService
   val oauth1Apis: OAuth1ApiService
   val oauth1Applications: OAuth1ApplicationService
   val oauth2Apis: OAuth2ApiService

--- a/app/services/PostgresDataService.scala
+++ b/app/services/PostgresDataService.scala
@@ -12,9 +12,11 @@ import models.accounts.ms_teams.botprofile.MSTeamsBotProfileService
 import models.accounts.oauth1api.OAuth1ApiService
 import models.accounts.oauth1application.OAuth1ApplicationService
 import models.accounts.oauth1token.OAuth1TokenService
+import models.accounts.oauth1tokenshare.OAuth1TokenShareService
 import models.accounts.oauth2api.OAuth2ApiService
 import models.accounts.oauth2application.OAuth2ApplicationService
 import models.accounts.oauth2token.OAuth2TokenService
+import models.accounts.oauth2tokenshare.OAuth2TokenShareService
 import models.accounts.simpletokenapi.SimpleTokenApiService
 import models.accounts.slack.botprofile.SlackBotProfileService
 import models.accounts.slack.slackmemberstatus.SlackMemberStatusService
@@ -82,6 +84,8 @@ class PostgresDataService @Inject() (
                                       val linkedOAuth1TokensProvider: Provider[LinkedOAuth1TokenService],
                                       val linkedOAuth2TokensProvider: Provider[LinkedOAuth2TokenService],
                                       val linkedSimpleTokensProvider: Provider[LinkedSimpleTokenService],
+                                      val oauth1TokenSharesProvider: Provider[OAuth1TokenShareService],
+                                      val oauth2TokenSharesProvider: Provider[OAuth2TokenShareService],
                                       val oauth1ApisProvider: Provider[OAuth1ApiService],
                                       val oauth1ApplicationsProvider: Provider[OAuth1ApplicationService],
                                       val oauth2ApisProvider: Provider[OAuth2ApiService],
@@ -147,6 +151,8 @@ class PostgresDataService @Inject() (
   val linkedOAuth1Tokens = linkedOAuth1TokensProvider.get
   val linkedOAuth2Tokens = linkedOAuth2TokensProvider.get
   val linkedSimpleTokens = linkedSimpleTokensProvider.get
+  val oauth1TokenShares = oauth1TokenSharesProvider.get
+  val oauth2TokenShares = oauth2TokenSharesProvider.get
   val oauth1Apis = oauth1ApisProvider.get
   val oauth1Applications = oauth1ApplicationsProvider.get
   val oauth2Apis = oauth2ApisProvider.get

--- a/conf/evolutions/default/153.sql
+++ b/conf/evolutions/default/153.sql
@@ -1,0 +1,45 @@
+# --- !Ups
+
+BEGIN;
+
+CREATE TABLE oauth1_token_shares (
+  application_id TEXT NOT NULL REFERENCES oauth1_applications(id),
+  user_id TEXT NOT NULL REFERENCES users(id),
+  team_id TEXT NOT NULL REFERENCES teams(id),
+  PRIMARY KEY (application_id, team_id)
+);
+
+CREATE INDEX oauth1_token_shares_application_id_index ON oauth1_applications(id);
+CREATE INDEX oauth1_token_shares_user_id_index ON users(id);
+CREATE INDEX oauth1_token_shares_team_id_index ON teams(id);
+
+CREATE TABLE oauth2_token_shares (
+  application_id TEXT NOT NULL REFERENCES oauth2_applications(id),
+  user_id TEXT NOT NULL REFERENCES users(id),
+  team_id TEXT NOT NULL REFERENCES teams(id),
+  PRIMARY KEY (application_id, team_id)
+);
+
+CREATE INDEX oauth2_token_shares_application_id_index ON oauth2_applications(id);
+CREATE INDEX oauth2_token_shares_user_id_index ON users(id);
+CREATE INDEX oauth2_token_shares_team_id_index ON teams(id);
+
+COMMIT;
+
+# --- !Downs
+
+BEGIN;
+
+DROP INDEX IF EXISTS oauth1_token_shares_application_id_index;
+DROP INDEX IF EXISTS oauth1_token_shares_user_id_index;
+DROP INDEX IF EXISTS oauth1_token_shares_team_id_index;
+
+DROP TABLE IF EXISTS oauth1_token_shares;
+
+DROP INDEX IF EXISTS oauth2_token_shares_application_id_index;
+DROP INDEX IF EXISTS oauth2_token_shares_user_id_index;
+DROP INDEX IF EXISTS oauth2_token_shares_team_id_index;
+
+DROP TABLE IF EXISTS oauth2_token_shares;
+
+COMMIT;

--- a/test/controllers/APIAccessControllerSpec.scala
+++ b/test/controllers/APIAccessControllerSpec.scala
@@ -33,7 +33,7 @@ class APIAccessControllerSpec extends PlaySpec with MockitoSugar {
     "Log user out and redirect to signin if not logged into the right team" in new TestContext {
       running(app) {
         val someOtherTeam = Team("")
-        val oauth2AppForOtherTeam = OAuth2Application(IDs.next, "", oauth2Api, IDs.next, IDs.next, None, someOtherTeam.id, isShared = false, maybeSharedTokenUserId = None)
+        val oauth2AppForOtherTeam = OAuth2Application(IDs.next, "", oauth2Api, IDs.next, IDs.next, None, someOtherTeam.id, isShared = false)
         when(dataService.oauth2Applications.find(oauth2AppForOtherTeam.id)).thenReturn(Future.successful(Some(oauth2AppForOtherTeam)))
         when(dataService.teams.find(someOtherTeam.id, user)).thenReturn(Future.successful(None))
         val request =
@@ -57,7 +57,7 @@ class APIAccessControllerSpec extends PlaySpec with MockitoSugar {
     "Proceed if logged into another team for shared oauth2 applications" in new TestContext {
       running(app) {
         val someOtherTeam = Team("Team1")
-        val oauth2AppForOtherTeam = OAuth2Application(IDs.next, "", oauth2Api, IDs.next, IDs.next, None, someOtherTeam.id, isShared = true, maybeSharedTokenUserId = None)
+        val oauth2AppForOtherTeam = OAuth2Application(IDs.next, "", oauth2Api, IDs.next, IDs.next, None, someOtherTeam.id, isShared = true)
         when(dataService.oauth2Applications.find(oauth2AppForOtherTeam.id)).thenReturn(Future.successful(Some(oauth2AppForOtherTeam)))
         when(dataService.teams.find(someOtherTeam.id, user)).thenReturn(Future.successful(None))
         implicit val request =
@@ -102,7 +102,7 @@ class APIAccessControllerSpec extends PlaySpec with MockitoSugar {
     lazy val oauth2ApiId = IDs.next
     lazy val oauth2Api = OAuth2Api(oauth2ApiId, "", AuthorizationCode, Some(authorizationUrl), "", None, None, None, None)
     lazy val oauth2AppId = IDs.next
-    lazy val oauth2App = OAuth2Application(oauth2AppId, "", oauth2Api, IDs.next, IDs.next, None, teamId, isShared = false, maybeSharedTokenUserId = None)
+    lazy val oauth2App = OAuth2Application(oauth2AppId, "", oauth2Api, IDs.next, IDs.next, None, teamId, isShared = false)
 
   }
 

--- a/test/controllers/IntegrationsControllerSpec.scala
+++ b/test/controllers/IntegrationsControllerSpec.scala
@@ -24,8 +24,8 @@ class IntegrationsControllerSpec extends PlaySpec with MockitoSugar {
     "404 for application from another team (even if it's shared)" in new MyContext {
       running(app) {
         val someOtherTeam = Team("Team1")
-        val oauth1AppForOtherTeam = OAuth1Application(IDs.next, "", oauth1Api, IDs.next, IDs.next, None, someOtherTeam.id, isShared = true, maybeSharedTokenUserId = None)
-        val oauth2AppForOtherTeam = OAuth2Application(IDs.next, "", oauth2Api, IDs.next, IDs.next, None, someOtherTeam.id, isShared = true, maybeSharedTokenUserId = None)
+        val oauth1AppForOtherTeam = OAuth1Application(IDs.next, "", oauth1Api, IDs.next, IDs.next, None, someOtherTeam.id, isShared = true)
+        val oauth2AppForOtherTeam = OAuth2Application(IDs.next, "", oauth2Api, IDs.next, IDs.next, None, someOtherTeam.id, isShared = true)
         val teamAccess = UserTeamAccess(user, team, Some(team), Some("TestBot"), isAdminAccess = false, isAdminUser = false)
         when(dataService.users.teamAccessFor(user, None)).thenReturn(Future.successful(teamAccess))
         when(dataService.users.isAdmin(user)).thenReturn(Future.successful(false))

--- a/test/mocks/MockDataService.scala
+++ b/test/mocks/MockDataService.scala
@@ -11,9 +11,11 @@ import models.accounts.ms_teams.botprofile.MSTeamsBotProfileService
 import models.accounts.oauth1api.OAuth1ApiService
 import models.accounts.oauth1application.OAuth1ApplicationService
 import models.accounts.oauth1token.OAuth1TokenService
+import models.accounts.oauth1tokenshare.OAuth1TokenShareService
 import models.accounts.oauth2api.OAuth2ApiService
 import models.accounts.oauth2application.OAuth2ApplicationService
 import models.accounts.oauth2token.OAuth2TokenService
+import models.accounts.oauth2tokenshare.OAuth2TokenShareService
 import models.accounts.simpletokenapi.SimpleTokenApiService
 import models.accounts.slack.botprofile.SlackBotProfileService
 import models.accounts.slack.slackmemberstatus.SlackMemberStatusService
@@ -82,6 +84,8 @@ class MockDataService extends DataService with MockitoSugar {
   val linkedOAuth1Tokens = mock[LinkedOAuth1TokenService]
   val linkedOAuth2Tokens = mock[LinkedOAuth2TokenService]
   val linkedSimpleTokens = mock[LinkedSimpleTokenService]
+  val oauth1TokenShares = mock[OAuth1TokenShareService]
+  val oauth2TokenShares = mock[OAuth2TokenShareService]
   val oauth1Apis = mock[OAuth1ApiService]
   val oauth1Applications = mock[OAuth1ApplicationService]
   val oauth2Apis = mock[OAuth2ApiService]

--- a/test/support/DBSpec.scala
+++ b/test/support/DBSpec.scala
@@ -214,7 +214,7 @@ trait DBSpec extends PlaySpec with GuiceOneAppPerSuite with MockitoSugar {
   }
 
   def newSavedOAuth2ApplicationFor(api: OAuth2Api, team: Team): OAuth2Application = {
-    runNow(dataService.oauth2Applications.save(OAuth2Application(IDs.next, IDs.next, api, IDs.next, IDs.next, None, team.id, isShared = false, maybeSharedTokenUserId = None)))
+    runNow(dataService.oauth2Applications.save(OAuth2Application(IDs.next, IDs.next, api, IDs.next, IDs.next, None, team.id, isShared = false)))
   }
 
   def newSavedRequiredOAuth2ConfigFor(api: OAuth2Api, groupVersion: BehaviorGroupVersion): RequiredOAuth2ApiConfig = {


### PR DESCRIPTION
- this allows us to avoid sharing tokens from shared apps