### PR TITLE
Scheduling: select a skill to preview triggers

### DIFF
--- a/app/assets/frontend/scheduling/scheduled_item_editor.tsx
+++ b/app/assets/frontend/scheduling/scheduled_item_editor.tsx
@@ -72,7 +72,7 @@ class ScheduledItemEditor extends React.Component<Props> {
     if (this.props.scheduledAction) {
       this.props.onChange(this.props.scheduledAction.clone({
         trigger: byTrigger ? "" : null,
-        behaviorGroupId: byTrigger ? null : this.props.groupId,
+        behaviorGroupId: this.props.groupId || this.props.scheduledAction.behaviorGroupId,
         behaviorId: null,
         arguments: [],
         scheduleType: byTrigger ? ScheduleType.Message : ScheduleType.Behavior


### PR DESCRIPTION
When creating new schedules, allow the user to select a skill even for message-based scheduling so they can see potential triggers