### PR TITLE
runtime_in_milliseconds should not be null

### DIFF
--- a/conf/evolutions/default/154.sql
+++ b/conf/evolutions/default/154.sql
@@ -1,11 +1,6 @@
 # --- !Ups
 
-BEGIN;
-
-DELETE FROM invocation_log_entries WHERE runtime_in_milliseconds IS NULL;
 ALTER TABLE invocation_log_entries ALTER runtime_in_milliseconds SET NOT NULL;
-
-COMMIT;
 
 # --- !Downs
 


### PR DESCRIPTION
Set the runtime_in_milliseconds column to be not nullable, since that's what the rest of our code expects and there are no known null values