### PR TITLE
See if I can speed up the skill manifest page

### DIFF
--- a/app/json/SkillManifestConfig.scala
+++ b/app/json/SkillManifestConfig.scala
@@ -44,7 +44,7 @@ object SkillManifestConfig {
             firstGroupVersions.find(_.group == group).flatMap(_.maybeAuthor.map(_.id)).contains(gcud.ellipsisUserId)
         }
         val maybeFirstDeployed = firstDeployments.find(_.groupId == group.id)
-        val maybeLastInvoked = lastGroupInvocations.find(_.behaviorVersion.group == groupVersion.group).map(_.createdAt)
+        val maybeLastInvoked = lastGroupInvocations.find(_.groupId == groupVersion.group.id).flatMap(_.maybeTimestamp)
         SkillManifestItemData(
           groupVersion.name,
           Some(group.id),

--- a/app/models/behaviors/invocationlogentry/InvocationLogEntryService.scala
+++ b/app/models/behaviors/invocationlogentry/InvocationLogEntryService.scala
@@ -31,7 +31,9 @@ trait InvocationLogEntryService {
 
   def lastForGroup(group: BehaviorGroup): Future[Option[OffsetDateTime]]
 
-  def lastForEachGroupForTeamAction(team: Team): DBIO[Seq[InvocationLogEntry]]
+  case class BehaviorGroupInvocationTimestamp(groupId: String, maybeTimestamp: Option[OffsetDateTime])
+
+  def lastForEachGroupForTeamAction(team: Team): DBIO[Seq[BehaviorGroupInvocationTimestamp]]
 
   def createForAction(
                        behaviorVersion: BehaviorVersion,

--- a/app/models/behaviors/invocationlogentry/InvocationLogEntryServiceImpl.scala
+++ b/app/models/behaviors/invocationlogentry/InvocationLogEntryServiceImpl.scala
@@ -117,8 +117,8 @@ class InvocationLogEntryServiceImpl @Inject() (
     dataService.run(lastForGroupAction(group))
   }
 
-  def lastForEachGroupForTeamAction(team: Team): DBIO[Seq[InvocationLogEntry]] = {
-    lastForEachGroupForTeamQuery(team.id).result.map(r => r.map(tuple2Entry))
+  def lastForEachGroupForTeamAction(team: Team): DBIO[Seq[BehaviorGroupInvocationTimestamp]] = {
+    lastForEachGroupForTeamQuery(team.id).result.map(r => r.map(ea => BehaviorGroupInvocationTimestamp(ea._1, ea._2)))
   }
 
   def createForAction(


### PR DESCRIPTION
Joining and filtering with an inner/outer group is slow on the invocation log entries table, so trying a groupBy...max query instead