### PR TITLE
Some fixes and improvements for scheduled messages that don't trigger any response

### DIFF
--- a/app/models/behaviors/BotResult.scala
+++ b/app/models/behaviors/BotResult.scala
@@ -460,7 +460,8 @@ case class NoResponseForBehaviorVersionResult(
                                                behaviorVersion: BehaviorVersion,
                                                maybeConversation: Option[Conversation],
                                                payloadJson: JsValue,
-                                               maybeLogResult: Option[AWSLambdaLogResult]
+                                               maybeLogResult: Option[AWSLambdaLogResult],
+                                               override val isForCopilot: Boolean
                                              ) extends BotResultWithLogResult with NoResponseResult {
 
   val maybeBehaviorVersion: Option[BehaviorVersion] = Some(behaviorVersion)

--- a/app/models/behaviors/behaviorversion/BehaviorVersion.scala
+++ b/app/models/behaviors/behaviorversion/BehaviorVersion.scala
@@ -122,7 +122,7 @@ case class BehaviorVersion(
       )
     }.getOrElse {
       if ((json \ NO_RESPONSE_KEY).toOption.exists(_.as[Boolean])) {
-        NoResponseForBehaviorVersionResult(event, this, maybeConversation, json, logResultOption)
+        NoResponseForBehaviorVersionResult(event, this, maybeConversation, json, logResultOption, isForCopilot)
       } else {
         if (json.toString == "null") {
           NoCallbackTriggeredResult(event, maybeConversation, this, dataService, configuration, developerContext)

--- a/app/models/behaviors/events/Event.scala
+++ b/app/models/behaviors/events/Event.scala
@@ -67,7 +67,12 @@ trait Event {
       s" in conversation [${convo.id}]"
     }.getOrElse("")
     val sourceText = maybeSource.getOrElse(logTextForResultSource)
-    val logIntro = s"Sending result $sourceText [${messageText}]$channelText$contextUserText$convoText: [${result.fullText}]"
+    val context = s"$sourceText [${messageText}]$channelText$contextUserText$convoText"
+    val logIntro = if (result.shouldSend) {
+      s"${result.resultType.toString} result $context: [${result.fullText}]"
+    } else {
+      s"${result.resultType.toString} result for $context (no response)"
+    }
     s"$logIntro\n${result.filesAsLogText}"
   }
 

--- a/app/models/behaviors/events/EventHandler.scala
+++ b/app/models/behaviors/events/EventHandler.scala
@@ -46,7 +46,7 @@ class EventHandler @Inject() (
         eventualResults
       }
       results <- {
-        if (behaviorResults.filter(_.shouldSend).isEmpty && event.isResponseExpected) {
+        if (shouldReportNoExactMatch(behaviorResults, event)) {
           event.noExactMatchResult(services).map { noMatchResult =>
             Seq(noMatchResult)
           }
@@ -55,6 +55,12 @@ class EventHandler @Inject() (
         }
       }
     } yield results
+  }
+
+  def shouldReportNoExactMatch(results: Seq[BotResult], event: Event): Boolean = {
+    val sendingResults = results.exists(_.shouldSend)
+    val nonCopilotResults = !results.forall(_.isForCopilot)
+    !sendingResults && event.isResponseExpected || !nonCopilotResults && event.maybeScheduled.isDefined
   }
 
   def cancelConversationResult(event: Event, conversation: Conversation, withMessage: String): Future[BotResult] = {

--- a/app/models/behaviors/events/ms_teams/MSTeamsMessageEvent.scala
+++ b/app/models/behaviors/events/ms_teams/MSTeamsMessageEvent.scala
@@ -91,7 +91,7 @@ case class MSTeamsMessageEvent(
 //    message.userList.map(MessageUserData.fromSlackUserData)
   }
 
-  override val isResponseExpected: Boolean = includesBotMention
+  override val isResponseExpected: Boolean = includesBotMention && maybeScheduled.isEmpty
 
   override def maybeOngoingConversation(dataService: DataService)(implicit ec: ExecutionContext): Future[Option[Conversation]] = {
     dataService.conversations.findOngoingFor(user, eventContext.name, maybeChannel, maybeThreadId, ellipsisTeamId).flatMap { maybeConvo =>

--- a/app/models/behaviors/events/slack/SlackMessageEvent.scala
+++ b/app/models/behaviors/events/slack/SlackMessageEvent.scala
@@ -76,7 +76,7 @@ case class SlackMessageEvent(
     UserData.allFromSlackUserDataListAction(message.userList, ellipsisTeamId, services)
   }
 
-  override val isResponseExpected: Boolean = includesBotMention
+  override val isResponseExpected: Boolean = includesBotMention && maybeScheduled.isEmpty
 
   override def maybeOngoingConversation(dataService: DataService)(implicit ec: ExecutionContext): Future[Option[Conversation]] = {
     dataService.conversations.findOngoingFor(eventContext.userIdForContext, eventContext.name, maybeChannel, maybeThreadId, ellipsisTeamId).flatMap { maybeConvo =>

--- a/app/models/behaviors/scheduling/Scheduled.scala
+++ b/app/models/behaviors/scheduling/Scheduled.scala
@@ -51,11 +51,10 @@ trait Scheduled {
     }
   }
 
-  def maybeEditScheduleUrlFor(configuration: Configuration): Option[String] = {
-    configuration.getOptional[String]("application.apiBaseUrl").map { baseUrl =>
-      val path = controllers.routes.ScheduledActionsController.index(Some(id), newSchedule = None, maybeChannel, skillId = None, Some(team.id), forceAdmin = None)
-      baseUrl + path
-    }
+  def editScheduleUrlFor(configuration: Configuration): String = {
+    val baseUrl = configuration.get[String]("application.apiBaseUrl")
+    val path = controllers.routes.ScheduledActionsController.index(Some(id), newSchedule = None, maybeChannel, skillId = None, Some(team.id), forceAdmin = None)
+    baseUrl + path
   }
 
   def isScheduledForDirectMessage: Boolean = {
@@ -105,9 +104,7 @@ trait Scheduled {
     } else {
       recurrence.displayString.trim ++ recipientDetails
     }
-    val scheduleLink = maybeEditScheduleUrlFor(configuration).map { url =>
-      s"_[✎ Edit]($url)_"
-    }.getOrElse("")
+    val scheduleLink = s"_[✎ Edit](${editScheduleUrlFor(configuration)})_"
     displayText(dataService).map { desc =>
       s"""
         |
@@ -260,9 +257,7 @@ trait Scheduled {
       sendResult(result, event, services).recover {
         case c: SlackMessageSenderChannelException => {
           if (slackUserId != profile.userId) {
-            val editLink = maybeEditScheduleUrlFor(services.configuration).map { url =>
-              s"[✎ Edit schedule]($url)"
-            }.getOrElse("")
+            val editLink = s"[✎ Edit schedule](${editScheduleUrlFor(services.configuration)})"
             for {
               scheduledDisplayText <- displayText(services.dataService)
               isAdminUserOnOtherTeam <- maybeUser.map { user =>

--- a/test/BotResultSpec.scala
+++ b/test/BotResultSpec.scala
@@ -180,7 +180,7 @@ class BotResultSpec extends PlaySpec with MockitoSugar with DBSpec with SlackCon
         val event: SlackMessageEvent = newEventFor(profile)
 
         val responseText = "response"
-        val result = NoResponseForBehaviorVersionResult(event, mock[BehaviorVersion], None, JsNull, None)
+        val result = NoResponseForBehaviorVersionResult(event, mock[BehaviorVersion], None, JsNull, None, isForCopilot = false)
         val resultTs: String = SlackTimestamp.now
 
         val conversation = newConversationFor(team, user, profile, event)


### PR DESCRIPTION
Fixes the `Here’s what I know related to “aws certs expiring in the next 30 days”.` scheduled bug.

- Only show the related help text if there are no non-copilot results
- Ensure NoResponse results track whether they are for copilot
- Improve the related help text for the scheduling case
- Make our result logging more accurate about whether a result was actually sent, and what kind of result it was