### PR TITLE
Use the listener behavior team when creating the MessageListenerData

### DIFF
--- a/app/assets/frontend/copilot/index.tsx
+++ b/app/assets/frontend/copilot/index.tsx
@@ -30,7 +30,7 @@ interface Result extends ResultJson {
 
 export interface Listener {
   id: string
-  channelId: string
+  channel: string
   channelName: Option<string>
 }
 
@@ -194,7 +194,7 @@ class Copilot extends React.Component<Props, State> {
       return (
         <span>
           <span>Unknown channel </span>
-          <span className="color-gray-medium">(ID {this.props.listener.channelId})</span>
+          <span className="color-gray-medium">(ID {this.props.listener.channel})</span>
         </span>
       );
     }

--- a/app/controllers/CopilotController.scala
+++ b/app/controllers/CopilotController.scala
@@ -53,7 +53,7 @@ class CopilotController @Inject()(
       maybeListener <- dataService.messageListeners.find(listenerId, user)
       teamAccess <- dataService.users.teamAccessFor(user, maybeListener.map(_.behavior.team.id))
       maybeListenerData <- maybeListener.map { listener =>
-        MessageListenerData.from(listener, teamAccess.loggedInTeam, services).map(Some(_))
+        MessageListenerData.from(listener, services).map(Some(_))
       }.getOrElse(Future.successful(None))
     } yield {
       render {


### PR DESCRIPTION
…not the logged-in team

- Fixes unknown channel in admin mode
- Fixes mismatched Slack user/team warnings