### PR TITLE
Fix bug with other people's DMs group on scheduling page

### DIFF
--- a/test/assets/frontend/scheduling/scheduling_spec.tsx
+++ b/test/assets/frontend/scheduling/scheduling_spec.tsx
@@ -487,7 +487,7 @@ describe('Scheduling', () => {
       }));
       const page = wrapper.page;
       const grouped = page.getScheduleByChannel();
-      expect(grouped.map((ea) => ea.channelId)).toEqual(["channel2", "channel1"]);
+      expect(grouped.map((ea) => ea.channelIds)).toEqual([new Set(["channel2"]), new Set(["channel1"])]);
       expect(grouped[0].actions).toEqual([action2, action4]);
       expect(grouped[1].actions).toEqual([action3, action1]);
     });


### PR DESCRIPTION
If you loaded the scheduling page with a DM channel ID as a filter, and there were multiple DM channels in the "other people's DMs" group, it would show no items.

This changes schedule groups to work with multiple channel IDs, and handles different forms of channel ID filters (single channel or multiple channel IDs munged together) gracefully.